### PR TITLE
Support go 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ go:
 - 1.5
 - 1.6
 - 1.7
+- 1.8
 script:
   - go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
 after_success:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Currently, the driver is tested on:
 - 1.5
 - 1.6
 - 1.7
+- 1.8
 
 ## Using the Driver
 

--- a/faunadb/benchmark_test.go
+++ b/faunadb/benchmark_test.go
@@ -8,11 +8,11 @@ import (
 )
 
 // Current results:
-// BenchmarkParseJSON-8               30000             40449 ns/op
-// BenchmarkDecodeValue-8             50000             24919 ns/op
-// BenchmarkEncodeValue-8            100000             23359 ns/op
-// BenchmarkWriteJSON-8               50000             30474 ns/op
-// BenchmarkExtactValue-8          20000000               107 ns/op
+// BenchmarkParseJSON-8               50000             38307 ns/op
+// BenchmarkDecodeValue-8             50000             24235 ns/op
+// BenchmarkEncodeValue-8            100000             22126 ns/op
+// BenchmarkWriteJSON-8               50000             28964 ns/op
+// BenchmarkExtactValue-8          20000000                97.4 ns/op
 
 type benchmarkStruct struct {
 	NonExistingField int


### PR DESCRIPTION
Go 1.8 was released 16th February: https://blog.golang.org/go1.8

I didn't add a change log because there was no change at all. The code is already compliant with 1.8 version.