### PR TITLE
Check for errors after creating test key

### DIFF
--- a/faunadb/client_test.go
+++ b/faunadb/client_test.go
@@ -187,10 +187,11 @@ func (s *ClientTestSuite) TestReturnUnauthorizedOnInvalidSecret() {
 }
 
 func (s *ClientTestSuite) TestReturnPermissionDeniedWhenAccessingRestrictedResource() {
-	key, _ := f.CreateKeyWithRole("client")
+	key, err := f.CreateKeyWithRole("client")
+	s.Require().NoError(err)
 	client := s.client.NewSessionClient(f.GetSecret(key))
 
-	_, err := client.Query(
+	_, err = client.Query(
 		f.Paginate(f.Ref("databases")),
 	)
 


### PR DESCRIPTION
Handles a non-sane situation where this test can be running without a valid server key, which previously resulted in the tests crashing.