### PR TITLE
Remove unneeded override from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-override RUNTIME_IMAGE ?= golang:1.8-alpine
+RUNTIME_IMAGE ?= golang:1.8-alpine
 DOCKER_RUN_FLAGS = -it --rm
 
 ifdef FAUNA_ROOT_KEY


### PR DESCRIPTION
Dunno why I thought this was needed.

Updating now so the makefiles are all inline across the drivers (that will have docker images).