### PR TITLE
Adds support to select_all function

### DIFF
--- a/faunadb/client_test.go
+++ b/faunadb/client_test.go
@@ -950,6 +950,38 @@ func (s *ClientTestSuite) TestEvalSelectExpression() {
 	s.Require().Equal("no food", food)
 }
 
+func (s *ClientTestSuite) TestEvalSelectAllExpression() {
+	var foo []string
+
+	s.queryAndDecode(
+		f.SelectAll(
+			"foo",
+			f.Arr{
+				f.Obj{"foo": "bar"},
+				f.Obj{"foo": "baz"},
+			},
+		),
+		&foo,
+	)
+
+	s.Require().Equal([]string{"bar", "baz"}, foo)
+
+	var numbers []int
+
+	s.queryAndDecode(
+		f.SelectAll(
+			f.Arr{"foo", 0},
+			f.Arr{
+				f.Obj{"foo": f.Arr{0, 1}},
+				f.Obj{"foo": f.Arr{2, 3}},
+			},
+		),
+		&numbers,
+	)
+
+	s.Require().Equal([]int{0, 2}, numbers)
+}
+
 func (s *ClientTestSuite) TestEvalAddExpression() {
 	var num int
 

--- a/faunadb/query.go
+++ b/faunadb/query.go
@@ -536,3 +536,10 @@ func Not(boolean interface{}) Expr { return fn1("not", boolean) }
 func Select(path, value interface{}, options ...OptionalParameter) Expr {
 	return fn2("select", path, "from", value, options...)
 }
+
+// SelectAll traverses into the value informed flattening all values under the desired path.
+//
+// See: https://fauna.com/documentation/queries#misc_functions
+func SelectAll(path, value interface{}) Expr {
+	return fn2("select_all", path, "from", value)
+}

--- a/faunadb/serialization_test.go
+++ b/faunadb/serialization_test.go
@@ -773,6 +773,19 @@ func TestSerializeSelect(t *testing.T) {
 	)
 }
 
+func TestSelializeSelectAll(t *testing.T) {
+	assertJSON(t,
+		SelectAll(
+			"foo",
+			Arr{
+				Obj{"foo": "bar"},
+				Obj{"foo": "baz"},
+			},
+		),
+		`{"from":[{"object":{"foo":"bar"}},{"object":{"foo":"baz"}}],"select_all":"foo"}`,
+	)
+}
+
 func TestSerializeAdd(t *testing.T) {
 	assertJSON(t,
 		Add(Arr{1, 2}),


### PR DESCRIPTION
This PR was repurposed, instead of adding a sugar for `select(...,all=true)` now it calls the function `select_all` directly