### PR TITLE
Fix parsing of @query types nested in objects

### DIFF
--- a/faunadb/deserialization_test.go
+++ b/faunadb/deserialization_test.go
@@ -151,6 +151,23 @@ func TestDeserializeQueryV(t *testing.T) {
 	require.Equal(t, QueryV{lambda}, query)
 }
 
+func TestDeserializeQueryVInsideObjectV(t *testing.T) {
+	var object ObjectV
+
+	lambda := json.RawMessage(`{"lambda": "x", "expr": {"var": "x"}}`)
+
+	require.NoError(t, decodeJSON(`{"a": "a", "b": {"lambda": {"@query": {"lambda": "x", "expr": {"var": "x"}}}}, "c": "c"}`, &object))
+	require.Equal(t, ObjectV{"a": StringV("a"), "b": ObjectV{"lambda": QueryV{lambda}}, "c": StringV("c")}, object)
+}
+
+func TestDeserializeInvalidQueryV(t *testing.T) {
+	var object ObjectV
+
+	require.EqualError(t,
+		decodeJSON(`{"query":{"@query": {}, "invalid":"what?"}`, &object),
+		`Expected end of object but got "invalid"`)
+}
+
 func TestDeserializeSetRefV(t *testing.T) {
 	var setRef SetRefV
 

--- a/faunadb/json.go
+++ b/faunadb/json.go
@@ -160,6 +160,13 @@ func (p *jsonParser) parseQuery() (value Value, err error) {
 		value = QueryV{lambda}
 	}
 
+	var token json.Token
+	if token, err = p.decoder.Token(); err == nil {
+		if token != json.Delim('}') {
+			err = wrongToken{"end of object", token}
+		}
+	}
+
 	return
 }
 


### PR DESCRIPTION
Because we were not consuming the closing character of the `@query` type, it was making the parser finish the parsing of `resource` property and thus moving the properties `permissions` and `role` to its parent
 
```json
{
  "resource": {
    "ref": { "@ref": "functions/create_entry3" },
    "class": { "@ref": "functions" },
    "ts": 1528404902084061,
    "name": "create_entry3",
    "body": {
      "@query": {
        "lambda": [ "title", "body" ],
        "expr": {
          "create": { "class": "posts" },
          "params": {
            "object": {
              "title": { "var": "title" },
              "body": { "var": "body" }
            }
          }
        }
      }
    },
    "permissions": { "call": "public" },
    "role": "server"
  }
}
```
so it was being parsed as
```json
{
  "resource": {
    "ref": { "@ref": "functions/create_entry3" },
    "class": { "@ref": "functions" },
    "ts": 1528404902084061,
    "name": "create_entry3",
    "body": {
      "@query": {
        "lambda": [ "title", "body" ],
        "expr": {
          "create": { "class": "posts" },
          "params": {
            "object": {
              "title": { "var": "title" },
              "body": { "var": "body" }
            }
          }
        }
      }
    }
  },
  "permissions": { "call": "public" },
  "role": "server"
}
```
since the drivers only extract the `resource` property from the response, the `permissions` and `role` properties was being discarded