### PR TITLE
ENG-160 : Allow encoding of arrays, not just slices

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,11 @@ GitHub pull requests are very welcome.
 
 Run `go get -t ./...` in order to install project's dependencies.
 
-Run tests with `FAUNA_ROOT_KEY="your-cloud-secret" go test ./...`.
+Run tests against FaunaDB Cloud by passing your root database key to the
+test suite, as follows: `FAUNA_ROOT_KEY="your-cloud-secret" go test ./...`.
+
+If you have access to another running FaunaDB database, use the
+`FAUNA_ENDPOINT` environment variable to specify its URI.
 
 Alternatively, tests can be run via a Docker container with
 `FAUNA_ROOT_KEY="your-cloud-secret" make docker-test` (an alternate

--- a/faunadb/encode.go
+++ b/faunadb/encode.go
@@ -70,7 +70,7 @@ func wrap(i interface{}) Expr {
 		value, _ = indirectValue(structToMap(value))
 		return wrapMap(value)
 
-	case reflect.Slice:
+	case reflect.Slice, reflect.Array:
 		return wrapArray(value)
 
 	default:

--- a/faunadb/encode_test.go
+++ b/faunadb/encode_test.go
@@ -91,8 +91,7 @@ func TestWrapStruct(t *testing.T) {
 	}
 }
 
-
-func TestWrapSlice(t *testing.T) {
+func TestWrapSliceAndArrays(t *testing.T) {
 	tests := []struct {
 		name     string
 		in       interface{}
@@ -101,6 +100,9 @@ func TestWrapSlice(t *testing.T) {
 		{"empty slice", []Expr{}, unescapedArr{}},
 		{"One element slice", []int{1}, unescapedArr{LongV(1)}},
 		{"Nested slice", [][]int{[]int{1}}, unescapedArr{unescapedArr{LongV(1)}}},
+
+		{"empty array", [0]Expr{}, unescapedArr{}},
+		{"One element array", [1]int{1}, unescapedArr{LongV(1)}},
 	}
 
 	for _, test := range tests {

--- a/faunadb/encode_test.go
+++ b/faunadb/encode_test.go
@@ -1,0 +1,112 @@
+package faunadb
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestWrapNil(t *testing.T) {
+	var in *string
+
+	actual := wrap(in)
+	expected := NullV{}
+	if actual != expected {
+		t.Errorf("Nil test failed: wrap(%#v) == %#v, expected %#v", in, actual, expected)
+	}
+}
+
+func TestWrapPODs(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       interface{}
+		expected Expr
+	}{
+		{"String", "abc", StringV("abc")},
+		{"Boolean true", true, BooleanV(true)},
+		{"Boolean false", false, BooleanV(false)},
+		{"Int", 42, LongV(42)},
+		{"Int8", int8(42), LongV(42)},
+		{"Int16", int16(42), LongV(42)},
+		{"Int32", int32(42), LongV(42)},
+		{"Int64", int64(42), LongV(42)},
+		{"Uint", 42, LongV(42)},
+		{"Uint8", uint8(42), LongV(42)},
+		{"Uint16", uint16(42), LongV(42)},
+		{"Uint32", uint32(42), LongV(42)},
+		{"Uint64", uint64(42), LongV(42)},
+		{"Float32", float32(1.0), DoubleV(1.0)},
+		{"Float64", float64(1.0), DoubleV(1.0)},
+	}
+
+	for _, test := range tests {
+		actual := wrap(test.in)
+		if actual != test.expected {
+			t.Errorf("POD test %s failed: wrap(%#v) in %#v, expected %#v", test.name, test.in, actual, test.expected)
+		}
+	}
+}
+
+func TestWrapMap(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       interface{}
+		expected Expr
+	}{
+		{"non-string key", map[int]string{4: "h"}, errMapKeyMustBeString},
+		{"string key", map[string]int{"h": 4},
+			unescapedObj{
+				"object": unescapedObj{
+					"h": LongV(4),
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		actual := wrap(test.in)
+		if !reflect.DeepEqual(actual, test.expected) {
+			t.Errorf("map test %s failed: wrap(%#v) in %#v, expected %#v", test.name, test.in, actual, test.expected)
+		}
+	}
+}
+
+func TestWrapStruct(t *testing.T) {
+	in := struct {
+		A string
+		B int
+	}{
+		"hello",
+		42,
+	}
+
+	actual := wrap(in)
+	expected := unescapedObj{
+		"object": unescapedObj{
+			"A": StringV("hello"),
+			"B": LongV(42),
+		},
+	}
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("Struct test failed: wrap(%#v) == %#v, expected %#v", in, actual, expected)
+	}
+}
+
+
+func TestWrapSlice(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       interface{}
+		expected Expr
+	}{
+		{"empty slice", []Expr{}, unescapedArr{}},
+		{"One element slice", []int{1}, unescapedArr{LongV(1)}},
+		{"Nested slice", [][]int{[]int{1}}, unescapedArr{unescapedArr{LongV(1)}}},
+	}
+
+	for _, test := range tests {
+		actual := wrap(test.in)
+		if !reflect.DeepEqual(actual, test.expected) {
+			t.Errorf("POD test %s failed: wrap(%#v) in %#v, expected %#v", test.name, test.in, actual, test.expected)
+		}
+	}
+}


### PR DESCRIPTION
IIRC, a customer request.

While I was in there, I also wrote a test that runs through all the cases of `wrap()`, since it seemed weird to only have a repo case for `reflect.Array` and nothing else :)

Tested via:
```
➜  faunadb-go git:(nathan/ENG-160_array_encoding) FAUNA_ENDPOINT=http://localhost:8443 FAUNA_ROOT_KEY=secret go test ./... 
ok      github.com/fauna/faunadb-go/faunadb     3.316s 
```