### PR TITLE
DRV-25: Accept nil as Null() expr

### DIFF
--- a/faunadb/client_test.go
+++ b/faunadb/client_test.go
@@ -376,7 +376,7 @@ func (s *ClientTestSuite) TestUpdateAnInstaceData() {
 		f.Update(ref,
 			f.Obj{"data": f.Obj{
 				"name": "Faerie Fire",
-				"cost": f.Null(),
+				"cost": nil,
 			}},
 		),
 	)
@@ -2215,6 +2215,7 @@ func (s *ClientTestSuite) TestTypeCheckFunctions() {
 	values := f.Arr{
 		bytes,
 		f.Null(),
+		nil,
 		90,
 		3.14,
 		true,
@@ -2282,7 +2283,7 @@ func (s *ClientTestSuite) TestTypeCheckFunctions() {
 		"integer":     1,
 		"index":       1,
 		"key":         1,
-		"null":        1,
+		"null":        2,
 		"number":      2,
 		"object":      5,
 		"ref":         10,

--- a/faunadb/encode.go
+++ b/faunadb/encode.go
@@ -24,7 +24,7 @@ func wrap(i interface{}) Expr {
 	value, valueType := indirectValue(i)
 	kind := value.Kind()
 
-	if kind == reflect.Ptr && value.IsNil() {
+	if (kind == reflect.Ptr || kind == reflect.Interface) && value.IsNil() {
 		return NullV{}
 	}
 

--- a/faunadb/serialization_test.go
+++ b/faunadb/serialization_test.go
@@ -385,6 +385,13 @@ func TestSerializeNull(t *testing.T) {
 	assertJSON(t, Null(), `null`)
 }
 
+func TestSerializeNil(t *testing.T) {
+	assertJSON(t, nil, `null`)
+	assertJSON(t, Arr{nil, 0}, `[null,0]`)
+	assertJSON(t, Arr{Obj{"hey": nil}, nil, NullV{}, Null()}, `[{"object":{"hey":null}},null,null,null]`)
+	assertJSON(t, Obj{"we_have": nil}, `{"object":{"we_have":null}}`)
+}
+
 func TestSerializeNullOnObject(t *testing.T) {
 	assertJSON(t, Obj{"data": Null()}, `{"object":{"data":null}}`)
 }


### PR DESCRIPTION
The Go driver accepts the native `true` and `false`, but not `nil`.