### PR TITLE
DRV-27: Implement String() for Expr, showing query

### DIFF
--- a/faunadb/functions_auth.go
+++ b/faunadb/functions_auth.go
@@ -1,0 +1,99 @@
+package faunadb
+
+// Authentication
+
+// Login creates a token for the provided ref.
+//
+// Parameters:
+//  ref Ref - A reference with credentials to authenticate against.
+//  params Object - An object of parameters to pass to the login function
+//    - password: The password used to login
+//
+// Returns:
+//  Key - a key with the secret to login.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#authentication
+func Login(ref, params interface{}) Expr {
+	return loginFn{Login: wrap(ref), Params: wrap(params)}
+}
+
+type loginFn struct {
+	fnApply
+	Login  Expr `json:"login"`
+	Params Expr `json:"params"`
+}
+
+func (fn loginFn) String() string { return printFn(fn) }
+
+// Logout deletes the current session token. If invalidateAll is true, logout will delete all tokens associated with the current session.
+//
+// Parameters:
+//  invalidateAll bool - If true, log out all tokens associated with the current session.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#authentication
+func Logout(invalidateAll interface{}) Expr { return logoutFn{Logout: wrap(invalidateAll)} }
+
+type logoutFn struct {
+	fnApply
+	Logout Expr `json:"logout"`
+}
+
+func (fn logoutFn) String() string { return printFn(fn) }
+
+// Identify checks the given password against the provided ref's credentials.
+//
+// Parameters:
+//  ref Ref - The reference to check the password against.
+//  password string - The credentials password to check.
+//
+// Returns:
+//  bool - true if the password is correct, false otherwise.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#authentication
+func Identify(ref, password interface{}) Expr {
+	return identifyFn{Identify: wrap(ref), Password: wrap(password)}
+}
+
+type identifyFn struct {
+	fnApply
+	Identify Expr `json:"identify"`
+	Password Expr `json:"password"`
+}
+
+func (fn identifyFn) String() string { return printFn(fn) }
+
+// Identity returns the document reference associated with the current key.
+//
+// For example, the current key token created using:
+//	Create(Tokens(), Obj{"document": someRef})
+// or via:
+//	Login(someRef, Obj{"password":"sekrit"})
+// will return "someRef" as the result of this function.
+//
+// Returns:
+//  Ref - The reference associated with the current key.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#authentication
+func Identity() Expr { return identityFn{Identity: NullV{}} }
+
+type identityFn struct {
+	fnApply
+	Identity Expr `json:"identity" faunarepr:"noargs"`
+}
+
+func (fn identityFn) String() string { return printFn(fn) }
+
+// HasIdentity checks if the current key has an identity associated to it.
+//
+// Returns:
+//  bool - true if the current key has an identity, false otherwise.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#authentication
+func HasIdentity() Expr { return hasIdentityFn{HasIdentity: NullV{}} }
+
+type hasIdentityFn struct {
+	fnApply
+	HasIdentity Expr `json:"has_identity" faunarepr:"noargs"`
+}
+
+func (fn hasIdentityFn) String() string { return printFn(fn) }

--- a/faunadb/functions_basic.go
+++ b/faunadb/functions_basic.go
@@ -1,0 +1,285 @@
+package faunadb
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Basic forms
+
+// Abort aborts the execution of the query
+//
+// Parameters:
+//  msg string - An error message.
+//
+// Returns:
+//  Error
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#basic-forms
+func Abort(msg interface{}) Expr { return abortFn{Abort: wrap(msg)} }
+
+type abortFn struct {
+	fnApply
+	Abort Expr `json:"abort"`
+}
+
+func (fn abortFn) String() string { return printFn(fn) }
+
+// Do sequentially evaluates its arguments, and returns the last expression.
+// If no expressions are provided, do returns an error.
+//
+// Parameters:
+//  exprs []Expr - A variable number of expressions to be evaluated.
+//
+// Returns:
+//  Value - The result of the last expression in the list.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#basic-forms
+func Do(exprs ...interface{}) Expr { return doFn{Do: wrap(varargs(exprs))} }
+
+type doFn struct {
+	fnApply
+	Do Expr `json:"do" faunarepr:"varargs"`
+}
+
+func (fn doFn) String() string { return printFn(fn) }
+
+// If evaluates and returns then or elze depending on the value of cond.
+// If cond evaluates to anything other than a boolean, if returns an “invalid argument” error
+//
+// Parameters:
+//  cond bool - A boolean expression.
+//  then Expr - The expression to run if condition is true.
+//  elze Expr - The expression to run if condition is false.
+//
+// Returns:
+//  Value - The result of either then or elze expression.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#basic-forms
+func If(cond, then, elze interface{}) Expr {
+	return ifFn{
+		If:   wrap(cond),
+		Then: wrap(then),
+		Else: wrap(elze),
+	}
+}
+
+type ifFn struct {
+	fnApply
+	If   Expr `json:"if"`
+	Then Expr `json:"then"`
+	Else Expr `json:"else"`
+}
+
+func (fn ifFn) String() string { return printFn(fn) }
+
+// Lambda creates an anonymous function. Mostly used with Collection functions.
+//
+// Parameters:
+//  varName string|[]string - A string or an array of strings of arguments name to be bound in the body of the lambda.
+//  expr Expr - An expression used as the body of the lambda.
+//
+// Returns:
+//  Value - The result of the body expression.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#basic-forms
+func Lambda(varName, expr interface{}) Expr {
+	return lambdaFn{
+		Lambda:     wrap(varName),
+		Expression: wrap(expr),
+	}
+}
+
+type lambdaFn struct {
+	fnApply
+	Lambda     Expr `json:"lambda"`
+	Expression Expr `json:"expr"`
+}
+
+func (fn lambdaFn) String() string { return printFn(fn) }
+
+// At execute an expression at a given timestamp.
+//
+// Parameters:
+//  timestamp time - The timestamp in which the expression will be evaluated.
+//  expr Expr - An expression to be evaluated.
+//
+// Returns:
+//  Value - The result of the given expression.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#basic-forms
+func At(timestamp, expr interface{}) Expr {
+	return atFn{
+		At:         wrap(timestamp),
+		Expression: wrap(expr),
+	}
+}
+
+type atFn struct {
+	fnApply
+	At         Expr `json:"at"`
+	Expression Expr `json:"expr"`
+}
+
+func (fn atFn) String() string { return printFn(fn) }
+
+// LetBuilder builds Let expressions
+type LetBuilder struct {
+	bindings unescapedArr
+}
+
+type letFn struct {
+	fnApply
+	Let Expr `json:"let"`
+	In  Expr `json:"in"`
+}
+
+func (fn letFn) String() string {
+	var sb strings.Builder
+	sb.WriteString("Let()")
+	switch arr := fn.Let.(type) {
+	case unescapedArr:
+		for _, elem := range arr {
+			m := elem.(unescapedObj)
+			for k, v := range m {
+				sb.WriteString(".Bind(" + strconv.Quote(k) + ", " + v.String() + ")")
+			}
+		}
+	default:
+		return "invalid type"
+	}
+	sb.WriteString(".In(" + fn.In.String() + ")")
+	return sb.String()
+}
+
+// Bind binds a variable name to a value and returns a LetBuilder
+func (lb *LetBuilder) Bind(key string, in interface{}) *LetBuilder {
+	binding := make(unescapedObj, 1)
+	binding[key] = wrap(in)
+	lb.bindings = append(lb.bindings, binding)
+	return lb
+}
+
+// In sets the expression to be evaluated and returns the prepared Let.
+func (lb *LetBuilder) In(in Expr) Expr {
+	return letFn{
+		Let: wrap(lb.bindings),
+		In:  in,
+	}
+}
+
+// Let binds values to one or more variables.
+//
+// Returns:
+//  *LetBuilder - Returns a LetBuilder.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#basic-forms
+func Let() *LetBuilder { return &LetBuilder{nil} }
+
+// Var refers to a value of a variable on the current lexical scope.
+//
+// Parameters:
+//  name string - The variable name.
+//
+// Returns:
+//  Value - The variable value.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#basic-forms
+func Var(name string) Expr { return varFn{Var: wrap(name)} }
+
+type varFn struct {
+	fnApply
+	Var Expr `json:"var"`
+}
+
+func (fn varFn) String() string { return printFn(fn) }
+
+// Call invokes the specified function passing in a variable number of arguments
+//
+// Parameters:
+//  ref Ref - The reference to the user defined functions to call.
+//  args []Value - A series of values to pass as arguments to the user defined function.
+//
+// Returns:
+//  Value - The return value of the user defined function.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#basic-forms
+func Call(ref interface{}, args ...interface{}) Expr {
+	return callFn{Call: wrap(ref), Params: wrap(varargs(args...))}
+}
+
+type callFn struct {
+	fnApply
+	Call   Expr `json:"call"`
+	Params Expr `json:"arguments"`
+}
+
+func (fn callFn) String() string { return printFn(fn) }
+
+// Query creates an instance of the @query type with the specified lambda
+//
+// Parameters:
+//  lambda Lambda - A lambda representation. See Lambda() function.
+//
+// Returns:
+//  Query - The lambda wrapped in a @query type.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#basic-forms
+func Query(lambda interface{}) Expr { return queryFn{Query: wrap(lambda)} }
+
+type queryFn struct {
+	fnApply
+	Query Expr `json:"query"`
+}
+
+func (fn queryFn) String() string { return printFn(fn) }
+
+// Select traverses into the provided value, returning the value at the given path.
+//
+// Parameters:
+//  path []Path - An array representing a path to pull from an object. Path can be either strings or numbers.
+//  value Object - The object to select from.
+//
+// Optional parameters:
+//  default Value - A default value if the path does not exist. See Default() function.
+//
+// Returns:
+//  Value - The value at the given path location.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#read-functions
+func Select(path, value interface{}, options ...OptionalParameter) Expr {
+	fn := selectFn{Select: wrap(path), From: wrap(value)}
+	return applyOptionals(fn, options)
+}
+
+type selectFn struct {
+	fnApply
+	Select  Expr `json:"select"`
+	From    Expr `json:"from"`
+	Default Expr `json:"default,omitempty" faunarepr:"optfn"`
+}
+
+func (fn selectFn) String() string { return printFn(fn) }
+
+// SelectAll traverses into the provided value flattening all values under the desired path.
+//
+// Parameters:
+//  path []Path - An array representing a path to pull from an object. Path can be either strings or numbers.
+//  value Object - The object to select from.
+//
+// Returns:
+//  Value - The value at the given path location.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#read-functions
+func SelectAll(path, value interface{}) Expr {
+	return selectAllFn{SelectAll: wrap(path), From: wrap(value)}
+}
+
+type selectAllFn struct {
+	fnApply
+	SelectAll Expr `json:"select_all"`
+	From      Expr `json:"from"`
+	Default   Expr `json:"default,omitempty" faunarepr:"optfn"`
+}
+
+func (fn selectAllFn) String() string { return printFn(fn) }

--- a/faunadb/functions_collections.go
+++ b/faunadb/functions_collections.go
@@ -1,0 +1,275 @@
+package faunadb
+
+// Collections
+
+// Map applies the lambda expression on each element of a collection or Page.
+// It returns the result of each application on a collection of the same type.
+//
+// Parameters:
+//  coll []Value - The collection of elements to iterate.
+//  lambda Lambda - A lambda function to be applied to each element of the collection. See Lambda() function.
+//
+// Returns:
+//  []Value - A new collection with elements transformed by the lambda function.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#collections
+func Map(coll, lambda interface{}) Expr { return mapFn{Map: wrap(lambda), Collection: wrap(coll)} }
+
+type mapFn struct {
+	fnApply
+	Map        Expr `json:"map"`
+	Collection Expr `json:"collection"`
+}
+
+func (fn mapFn) String() string { return printFn(fn) }
+
+// Foreach applies the lambda expression on each element of a collection or Page.
+// The original collection is returned.
+//
+// Parameters:
+//  coll []Value - The collection of elements to iterate.
+//  lambda Lambda - A lambda function to be applied to each element of the collection. See Lambda() function.
+//
+// Returns:
+//  []Value - The original collection.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#collections
+func Foreach(coll, lambda interface{}) Expr {
+	return foreachFn{Foreach: wrap(lambda), Collection: wrap(coll)}
+}
+
+type foreachFn struct {
+	fnApply
+	Foreach    Expr `json:"foreach"`
+	Collection Expr `json:"collection"`
+}
+
+func (fn foreachFn) String() string { return printFn(fn) }
+
+// Filter applies the lambda expression on each element of a collection or Page.
+// It returns a new collection of the same type containing only the elements in which the
+// function application returned true.
+//
+// Parameters:
+//  coll []Value - The collection of elements to iterate.
+//  lambda Lambda - A lambda function to be applied to each element of the collection. The lambda function must return a boolean value. See Lambda() function.
+//
+// Returns:
+//  []Value - A new collection.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#collections
+func Filter(coll, lambda interface{}) Expr {
+	return filterFn{Filter: wrap(lambda), Collection: wrap(coll)}
+}
+
+type filterFn struct {
+	fnApply
+	Filter     Expr `json:"filter"`
+	Collection Expr `json:"collection"`
+}
+
+func (fn filterFn) String() string { return printFn(fn) }
+
+// Take returns a new collection containing num elements from the head of the original collection.
+//
+// Parameters:
+//  num int64 - The number of elements to take from the collection.
+//  coll []Value - The collection of elements.
+//
+// Returns:
+//  []Value - A new collection.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#collections
+func Take(num, coll interface{}) Expr { return takeFn{Take: wrap(num), Collection: wrap(coll)} }
+
+type takeFn struct {
+	fnApply
+	Take       Expr `json:"take"`
+	Collection Expr `json:"collection"`
+}
+
+func (fn takeFn) String() string { return printFn(fn) }
+
+// Drop returns a new collection containing the remaining elements from the original collection
+// after num elements have been removed.
+//
+// Parameters:
+//  num int64 - The number of elements to drop from the collection.
+//  coll []Value - The collection of elements.
+//
+// Returns:
+//  []Value - A new collection.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#collections
+func Drop(num, coll interface{}) Expr { return dropFn{Drop: wrap(num), Collection: wrap(coll)} }
+
+type dropFn struct {
+	fnApply
+	Drop       Expr `json:"drop"`
+	Collection Expr `json:"collection"`
+}
+
+func (fn dropFn) String() string { return printFn(fn) }
+
+// Prepend returns a new collection that is the result of prepending elems to coll.
+//
+// Parameters:
+//  elems []Value - Elements to add to the beginning of the other collection.
+//  coll []Value - The collection of elements.
+//
+// Returns:
+//  []Value - A new collection.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#collections
+func Prepend(elems, coll interface{}) Expr {
+	return prependFn{Prepend: wrap(elems), Collection: wrap(coll)}
+}
+
+type prependFn struct {
+	fnApply
+	Prepend    Expr `json:"prepend"`
+	Collection Expr `json:"collection"`
+}
+
+func (fn prependFn) String() string { return printFn(fn) }
+
+// Append returns a new collection that is the result of appending elems to coll.
+//
+// Parameters:
+//  elems []Value - Elements to add to the end of the other collection.
+//  coll []Value - The collection of elements.
+//
+// Returns:
+//  []Value - A new collection.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#collections
+func Append(elems, coll interface{}) Expr {
+	return appendFn{Append: wrap(elems), Collection: wrap(coll)}
+}
+
+type appendFn struct {
+	fnApply
+	Append     Expr `json:"append"`
+	Collection Expr `json:"collection"`
+}
+
+func (fn appendFn) String() string { return printFn(fn) }
+
+// IsEmpty returns true if the collection is the empty set, else false.
+//
+// Parameters:
+//  coll []Value - The collection of elements.
+//
+// Returns:
+//   bool - True if the collection is empty, else false.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#collections
+func IsEmpty(coll interface{}) Expr { return isEmptyFn{IsEmpty: wrap(coll)} }
+
+type isEmptyFn struct {
+	fnApply
+	IsEmpty Expr `json:"is_empty"`
+}
+
+func (fn isEmptyFn) String() string { return printFn(fn) }
+
+// IsNonEmpty returns false if the collection is the empty set, else true
+//
+// Parameters:
+//  coll []Value - The collection of elements.
+//
+// Returns:
+//   bool - True if the collection is not empty, else false.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#collections
+func IsNonEmpty(coll interface{}) Expr { return isNonEmptyFn{IsNonEmpty: wrap(coll)} }
+
+type isNonEmptyFn struct {
+	fnApply
+	IsNonEmpty Expr `json:"is_nonempty"`
+}
+
+func (fn isNonEmptyFn) String() string { return printFn(fn) }
+
+// Contains checks if the provided value contains the path specified.
+//
+// Parameters:
+//  path Path - An array representing a path to check for the existence of. Path can be either strings or ints.
+//  value Object - An object to search against.
+//
+// Returns:
+//  bool - true if the path contains any value, false otherwise.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
+func Contains(path, value interface{}) Expr {
+	return containsFn{Contains: wrap(path), Value: wrap(value)}
+}
+
+type containsFn struct {
+	fnApply
+	Contains Expr `json:"contains"`
+	Value    Expr `json:"in"`
+}
+
+func (fn containsFn) String() string { return printFn(fn) }
+
+// Count returns the number of elements in the collection.
+//
+// Parameters:
+// collection Expr - the collection
+//
+// Returns:
+// a new Expr instance
+//
+// See: https://docs.fauna.com/fauna/current/api/fql/functions/count
+func Count(collection interface{}) Expr {
+	return countFn{Count: wrap(collection)}
+}
+
+type countFn struct {
+	fnApply
+	Count Expr `json:"count"`
+}
+
+func (fn countFn) String() string { return printFn(fn) }
+
+// Sum sums the elements in the collection.
+//
+// Parameters:
+// collection Expr - the collection
+//
+// Returns:
+// a new Expr instance
+//
+// See: https://docs.fauna.com/fauna/current/api/fql/functions/sum
+func Sum(collection interface{}) Expr {
+	return sumFn{Sum: wrap(collection)}
+}
+
+type sumFn struct {
+	fnApply
+	Sum Expr `json:"sum"`
+}
+
+func (fn sumFn) String() string { return printFn(fn) }
+
+// Mean returns the mean of all elements in the collection.
+//
+// Parameters:
+//
+// collection Expr - the collection
+//
+// Returns:
+// a new Expr instance
+//
+// See: https://docs.fauna.com/fauna/current/api/fql/functions/mean
+func Mean(collection interface{}) Expr {
+	return meanFn{Mean: wrap(collection)}
+}
+
+type meanFn struct {
+	fnApply
+	Mean Expr `json:"mean"`
+}
+
+func (fn meanFn) String() string { return printFn(fn) }

--- a/faunadb/functions_datetime.go
+++ b/faunadb/functions_datetime.go
@@ -1,0 +1,349 @@
+package faunadb
+
+// Time and Date
+
+// Time constructs a time from a ISO 8601 offset date/time string.
+//
+// Parameters:
+//  str string - A string to convert to a time object.
+//
+// Returns:
+//  time - A time object.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#time-and-date
+func Time(str interface{}) Expr { return timeFn{Time: wrap(str)} }
+
+type timeFn struct {
+	fnApply
+	Time Expr `json:"time"`
+}
+
+func (fn timeFn) String() string { return printFn(fn) }
+
+// TimeAdd returns a new time or date with the offset in terms of the unit
+// added.
+//
+// Parameters:
+// base        -  the base time or data
+// offset      -  the number of units
+// unit        -  the unit type
+//
+// Returns:
+// Expr
+//
+//See: https://docs.fauna.com/fauna/current/api/fql/functions/timeadd
+func TimeAdd(base interface{}, offset interface{}, unit interface{}) Expr {
+	return timeAddFn{TimeAdd: wrap(base), Offset: wrap(offset), Unit: wrap(unit)}
+}
+
+type timeAddFn struct {
+	fnApply
+	TimeAdd Expr `json:"time_add"`
+	Offset  Expr `json:"offset"`
+	Unit    Expr `json:"unit"`
+}
+
+func (fn timeAddFn) String() string { return printFn(fn) }
+
+// TimeSubtract returns a new time or date with the offset in terms of the unit
+// subtracted.
+//
+// Parameters:
+// base        -  the base time or data
+// offset      -  the number of units
+// unit        -  the unit type
+//
+// Returns:
+// Expr
+//
+//See: https://docs.fauna.com/fauna/current/api/fql/functions/timesubtract
+func TimeSubtract(base interface{}, offset interface{}, unit interface{}) Expr {
+	return timeSubtractFn{TimeSubtract: wrap(base), Offset: wrap(offset), Unit: wrap(unit)}
+}
+
+type timeSubtractFn struct {
+	fnApply
+	TimeSubtract Expr `json:"time_subtract"`
+	Offset       Expr `json:"offset"`
+	Unit         Expr `json:"unit"`
+}
+
+func (fn timeSubtractFn) String() string { return printFn(fn) }
+
+// TimeDiff returns the number of intervals in terms of the unit between
+// two times or dates. Both start and finish must be of the same
+// type.
+//
+// Parameters:
+//   start the starting time or date, inclusive
+//   finish the ending time or date, exclusive
+//   unit the unit type//
+// Returns:
+// Expr
+//
+//See: https://docs.fauna.com/fauna/current/api/fql/functions/timediff
+func TimeDiff(start interface{}, finish interface{}, unit interface{}) Expr {
+	return timeDiffFn{TimeDiff: wrap(start), Other: wrap(finish), Unit: wrap(unit)}
+}
+
+type timeDiffFn struct {
+	fnApply
+	TimeDiff Expr `json:"time_diff"`
+	Other    Expr `json:"other"`
+	Unit     Expr `json:"unit"`
+}
+
+func (fn timeDiffFn) String() string { return printFn(fn) }
+
+// Date constructs a date from a ISO 8601 offset date/time string.
+//
+// Parameters:
+//  str string - A string to convert to a date object.
+//
+// Returns:
+//  date - A date object.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#time-and-date
+func Date(str interface{}) Expr { return dateFn{Date: wrap(str)} }
+
+type dateFn struct {
+	fnApply
+	Date Expr `json:"date"`
+}
+
+func (fn dateFn) String() string { return printFn(fn) }
+
+// Epoch constructs a time relative to the epoch "1970-01-01T00:00:00Z".
+//
+// Parameters:
+//  num int64 - The number of units from Epoch.
+//  unit string - The unit of number. One of TimeUnitSecond, TimeUnitMillisecond, TimeUnitMicrosecond, TimeUnitNanosecond.
+//
+// Returns:
+//  time - A time object.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#time-and-date
+func Epoch(num, unit interface{}) Expr { return epochFn{Epoch: wrap(num), Unit: wrap(unit)} }
+
+type epochFn struct {
+	fnApply
+	Epoch Expr `json:"epoch"`
+	Unit  Expr `json:"unit"`
+}
+
+func (fn epochFn) String() string { return printFn(fn) }
+
+// Now returns the current snapshot time.
+//
+// Returns:
+// Expr
+//
+// See: https://docs.fauna.com/fauna/current/api/fql/functions/now
+func Now() Expr {
+	return nowFn{Now: NullV{}}
+}
+
+type nowFn struct {
+	fnApply
+	Now Expr `json:"now" faunarepr:"noargs"`
+}
+
+func (fn nowFn) String() string { return printFn(fn) }
+
+// ToSeconds converts a time expression to seconds since the UNIX epoch.
+//
+// Parameters:
+//    value Object - The expression to convert.
+//
+// Returns:
+//   time - A time literal.
+func ToSeconds(value interface{}) Expr {
+	return toSecondsFn{ToSeconds: wrap(value)}
+}
+
+type toSecondsFn struct {
+	fnApply
+	ToSeconds Expr `json:"to_seconds"`
+}
+
+func (fn toSecondsFn) String() string { return printFn(fn) }
+
+// ToMillis converts a time expression to milliseconds since the UNIX epoch.
+//
+// Parameters:
+//    value Object - The expression to convert.
+//
+// Returns:
+//   time - A time literal.
+func ToMillis(value interface{}) Expr {
+	return toMillisFn{ToMillis: wrap(value)}
+}
+
+type toMillisFn struct {
+	fnApply
+	ToMillis Expr `json:"to_millis"`
+}
+
+func (fn toMillisFn) String() string { return printFn(fn) }
+
+// ToMicros converts a time expression to microseconds since the UNIX epoch.
+//
+// Parameters:
+//    value Object - The expression to convert.
+//
+// Returns:
+//   time - A time literal.
+func ToMicros(value interface{}) Expr {
+	return toMicrosFn{ToMicros: wrap(value)}
+}
+
+type toMicrosFn struct {
+	fnApply
+	ToMicros Expr `json:"to_micros"`
+}
+
+func (fn toMicrosFn) String() string { return printFn(fn) }
+
+// Year returns the time expression's year, following the ISO-8601 standard.
+//
+// Parameters:
+//    value Object - The expression to convert.
+//
+// Returns:
+//   time - year.
+func Year(value interface{}) Expr {
+	return yearFn{Year: wrap(value)}
+}
+
+type yearFn struct {
+	fnApply
+	Year Expr `json:"year"`
+}
+
+func (fn yearFn) String() string { return printFn(fn) }
+
+// Month returns a time expression's month of the year, from 1 to 12.
+//
+// Parameters:
+//    value Object - The expression to convert.
+//
+// Returns:
+//   time - Month.
+func Month(value interface{}) Expr {
+	return monthFn{Month: wrap(value)}
+}
+
+type monthFn struct {
+	fnApply
+	Month Expr `json:"month"`
+}
+
+func (fn monthFn) String() string { return printFn(fn) }
+
+// Hour returns a time expression's hour of the day, from 0 to 23.
+//
+// Parameters:
+//    value Object - The expression to convert.
+//
+// Returns:
+//   time - year.
+func Hour(value interface{}) Expr {
+	return hourFn{Hour: wrap(value)}
+}
+
+type hourFn struct {
+	fnApply
+	Hour Expr `json:"hour"`
+}
+
+func (fn hourFn) String() string { return printFn(fn) }
+
+// Minute returns a time expression's minute of the hour, from 0 to 59.
+//
+// Parameters:
+//    value Object - The expression to convert.
+//
+// Returns:
+//   time - year.
+func Minute(value interface{}) Expr {
+	return minuteFn{Minute: wrap(value)}
+}
+
+type minuteFn struct {
+	fnApply
+	Minute Expr `json:"minute"`
+}
+
+func (fn minuteFn) String() string { return printFn(fn) }
+
+// Second returns a time expression's second of the minute, from 0 to 59.
+//
+// Parameters:
+//    value Object - The expression to convert.
+//
+// Returns:
+//   time - year.
+func Second(value interface{}) Expr {
+	return secondFn{Second: wrap(value)}
+}
+
+type secondFn struct {
+	fnApply
+	Second Expr `json:"second"`
+}
+
+func (fn secondFn) String() string { return printFn(fn) }
+
+// DayOfMonth returns a time expression's day of the month, from 1 to 31.
+//
+// Parameters:
+//    value Object - The expression to convert.
+//
+// Returns:
+//   time - day of month.
+func DayOfMonth(value interface{}) Expr {
+	return dayOfMonthFn{DayOfMonth: wrap(value)}
+}
+
+type dayOfMonthFn struct {
+	fnApply
+	DayOfMonth Expr `json:"day_of_month"`
+}
+
+func (fn dayOfMonthFn) String() string { return printFn(fn) }
+
+// DayOfWeek returns a time expression's day of the week following ISO-8601 convention, from 1 (Monday) to 7 (Sunday).
+//
+// Parameters:
+//    value Object - The expression to convert.
+//
+// Returns:
+//   time - day of week.
+func DayOfWeek(value interface{}) Expr {
+	return dayOfWeekFn{DayOfWeek: wrap(value)}
+}
+
+type dayOfWeekFn struct {
+	fnApply
+	DayOfWeek Expr `json:"day_of_week"`
+}
+
+func (fn dayOfWeekFn) String() string { return printFn(fn) }
+
+// DayOfYear eturns a time expression's day of the year, from 1 to 365, or 366 in a leap year.
+//
+// Parameters:
+//    value Object - The expression to convert.
+//
+// Returns:
+//   time - Day of the year.
+func DayOfYear(value interface{}) Expr {
+	return dayOfYearFn{DayOfYear: wrap(value)}
+}
+
+type dayOfYearFn struct {
+	fnApply
+	DayOfYear Expr `json:"day_of_year"`
+}
+
+func (fn dayOfYearFn) String() string { return printFn(fn) }

--- a/faunadb/functions_logic.go
+++ b/faunadb/functions_logic.go
@@ -1,0 +1,186 @@
+package faunadb
+
+// Equals checks if all args are equivalents.
+//
+// Parameters:
+//  args []Value - A collection of expressions to check for equivalence.
+//
+// Returns:
+//  bool - true if all elements are equals, false otherwise.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
+func Equals(args ...interface{}) Expr { return equalsFn{Equals: wrap(varargs(args...))} }
+
+type equalsFn struct {
+	fnApply
+	Equals Expr `json:"equals" faunarepr:"varargs"`
+}
+
+func (fn equalsFn) String() string { return printFn(fn) }
+
+// Any evaluates to true if any element of the collection is true.
+//
+// Parameters:
+// collection  - the collection
+//
+// Returns:
+// Expr
+//
+// See: https://docs.fauna.com/fauna/current/api/fql/functions/any
+func Any(collection interface{}) Expr {
+	return anyFn{Any: wrap(collection)}
+}
+
+type anyFn struct {
+	fnApply
+	Any Expr `json:"any"`
+}
+
+func (fn anyFn) String() string { return printFn(fn) }
+
+// All evaluates to true if all elements of the collection are true.
+//
+// Parameters:
+// collection - the collection
+//
+// Returns:
+// Expr
+//
+// See: https://docs.fauna.com/fauna/current/api/fql/functions/all
+func All(collection interface{}) Expr {
+	return allFn{All: wrap(collection)}
+}
+
+type allFn struct {
+	fnApply
+	All Expr `json:"all"`
+}
+
+func (fn allFn) String() string { return printFn(fn) }
+
+// LT returns true if each specified value is less than all the subsequent values. Otherwise LT returns false.
+//
+// Parameters:
+//  args []number - A collection of terms to compare.
+//
+// Returns:
+//  bool - true if all elements are less than each other from left to right.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
+func LT(args ...interface{}) Expr { return ltFn{LT: wrap(varargs(args...))} }
+
+type ltFn struct {
+	fnApply
+	LT Expr `json:"lt" faunarepr:"varargs"`
+}
+
+func (fn ltFn) String() string { return printFn(fn) }
+
+// LTE returns true if each specified value is less than or equal to all subsequent values. Otherwise LTE returns false.
+//
+// Parameters:
+//  args []number - A collection of terms to compare.
+//
+// Returns:
+//  bool - true if all elements are less than of equals each other from left to right.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
+func LTE(args ...interface{}) Expr { return lteFn{LTE: wrap(varargs(args...))} }
+
+type lteFn struct {
+	fnApply
+	LTE Expr `json:"lte" faunarepr:"varargs"`
+}
+
+func (fn lteFn) String() string { return printFn(fn) }
+
+// GT returns true if each specified value is greater than all subsequent values. Otherwise GT returns false.
+// and false otherwise.
+//
+// Parameters:
+//  args []number - A collection of terms to compare.
+//
+// Returns:
+//  bool - true if all elements are greather than to each other from left to right.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
+func GT(args ...interface{}) Expr { return gtFn{GT: wrap(varargs(args...))} }
+
+type gtFn struct {
+	fnApply
+	GT Expr `json:"gt" faunarepr:"varargs"`
+}
+
+func (fn gtFn) String() string { return printFn(fn) }
+
+// GTE returns true if each specified value is greater than or equal to all subsequent values. Otherwise GTE returns false.
+//
+// Parameters:
+//  args []number - A collection of terms to compare.
+//
+// Returns:
+//  bool - true if all elements are greather than or equals to each other from left to right.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
+func GTE(args ...interface{}) Expr { return gteFn{GTE: wrap(varargs(args...))} }
+
+type gteFn struct {
+	fnApply
+	GTE Expr `json:"gte" faunarepr:"varargs"`
+}
+
+func (fn gteFn) String() string { return printFn(fn) }
+
+// And returns the conjunction of a list of boolean values.
+//
+// Parameters:
+//  args []bool - A collection to compute the conjunction of.
+//
+// Returns:
+//  bool - true if all elements are true, false otherwise.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
+func And(args ...interface{}) Expr { return andFn{And: wrap(varargs(args...))} }
+
+type andFn struct {
+	fnApply
+	And Expr `json:"and" faunarepr:"varargs"`
+}
+
+func (fn andFn) String() string { return printFn(fn) }
+
+// Or returns the disjunction of a list of boolean values.
+//
+// Parameters:
+//  args []bool - A collection to compute the disjunction of.
+//
+// Returns:
+//  bool - true if at least one element is true, false otherwise.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
+func Or(args ...interface{}) Expr { return orFn{Or: wrap(varargs(args...))} }
+
+type orFn struct {
+	fnApply
+	Or Expr `json:"or" faunarepr:"varargs"`
+}
+
+func (fn orFn) String() string { return printFn(fn) }
+
+// Not returns the negation of a boolean value.
+//
+// Parameters:
+//  boolean bool - A boolean to produce the negation of.
+//
+// Returns:
+//  bool - The value negated.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
+func Not(boolean interface{}) Expr { return notFn{Not: wrap(boolean)} }
+
+type notFn struct {
+	fnApply
+	Not Expr `json:"not"`
+}
+
+func (fn notFn) String() string { return printFn(fn) }

--- a/faunadb/functions_math.go
+++ b/faunadb/functions_math.go
@@ -1,0 +1,627 @@
+package faunadb
+
+// Abs computes the absolute value of a number.
+//
+// Parameters:
+//  value number - The number to take the absolute value of
+//
+// Returns:
+//  number - The abosulte value of a number
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
+func Abs(value interface{}) Expr { return absFn{Abs: wrap(value)} }
+
+type absFn struct {
+	fnApply
+	Abs Expr `json:"abs"`
+}
+
+func (fn absFn) String() string { return printFn(fn) }
+
+// Acos computes the arccosine of a number.
+//
+// Parameters:
+//  value number - The number to take the arccosine of
+//
+// Returns:
+//  number - The arccosine of a number
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
+func Acos(value interface{}) Expr { return acosFn{Acos: wrap(value)} }
+
+type acosFn struct {
+	fnApply
+	Acos Expr `json:"acos"`
+}
+
+func (fn acosFn) String() string { return printFn(fn) }
+
+// Asin computes the arcsine of a number.
+//
+// Parameters:
+//  value number - The number to take the arcsine of
+//
+// Returns:
+//  number - The arcsine of a number
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
+func Asin(value interface{}) Expr { return asinFn{Asin: wrap(value)} }
+
+type asinFn struct {
+	fnApply
+	Asin Expr `json:"asin"`
+}
+
+func (fn asinFn) String() string { return printFn(fn) }
+
+// Atan computes the arctan of a number.
+//
+// Parameters:
+//  value number - The number to take the arctan of
+//
+// Returns:
+//  number - The arctan of a number
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
+func Atan(value interface{}) Expr { return atanFn{Atan: wrap(value)} }
+
+type atanFn struct {
+	fnApply
+	Atan Expr `json:"atan"`
+}
+
+func (fn atanFn) String() string { return printFn(fn) }
+
+// Add computes the sum of a list of numbers.
+//
+// Parameters:
+//  args []number - A collection of numbers to sum together.
+//
+// Returns:
+//  number - The sum of all elements.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
+func Add(args ...interface{}) Expr { return addFn{Add: wrap(varargs(args...))} }
+
+type addFn struct {
+	fnApply
+	Add Expr `json:"add" faunarepr:"varargs"`
+}
+
+func (fn addFn) String() string { return printFn(fn) }
+
+// BitAnd computes the and of a list of numbers.
+//
+// Parameters:
+//  args []number - A collection of numbers to and together.
+//
+// Returns:
+//  number - The and of all elements.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
+func BitAnd(args ...interface{}) Expr { return bitAndFn{BitAnd: wrap(varargs(args...))} }
+
+type bitAndFn struct {
+	fnApply
+	BitAnd Expr `json:"bitand" faunarepr:"varargs"`
+}
+
+func (fn bitAndFn) String() string { return printFn(fn) }
+
+// BitNot computes the 2's complement of a number
+//
+// Parameters:
+//  value number - A numbers to not
+//
+// Returns:
+//  number - The not of an element
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
+func BitNot(value interface{}) Expr { return bitNotFn{BitNot: wrap(value)} }
+
+type bitNotFn struct {
+	fnApply
+	BitNot Expr `json:"bitnot"`
+}
+
+func (fn bitNotFn) String() string { return printFn(fn) }
+
+// BitOr computes the OR of a list of numbers.
+//
+// Parameters:
+//  args []number - A collection of numbers to OR together.
+//
+// Returns:
+//  number - The OR of all elements.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
+func BitOr(args ...interface{}) Expr { return bitOrFn{BitOr: wrap(varargs(args...))} }
+
+type bitOrFn struct {
+	fnApply
+	BitOr Expr `json:"bitor" faunarepr:"varargs"`
+}
+
+func (fn bitOrFn) String() string { return printFn(fn) }
+
+// BitXor computes the XOR of a list of numbers.
+//
+// Parameters:
+//  args []number - A collection of numbers to XOR together.
+//
+// Returns:
+//  number - The XOR of all elements.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
+func BitXor(args ...interface{}) Expr { return bitXorFn{BitXor: wrap(varargs(args...))} }
+
+type bitXorFn struct {
+	fnApply
+	BitXor Expr `json:"bitxor" faunarepr:"varargs"`
+}
+
+func (fn bitXorFn) String() string { return printFn(fn) }
+
+// Ceil computes the largest integer greater than or equal to
+//
+// Parameters:
+//  value number - A numbers to compute the ceil of
+//
+// Returns:
+//  number - The ceil of value
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
+func Ceil(value interface{}) Expr { return ceilFn{Ceil: wrap(value)} }
+
+type ceilFn struct {
+	fnApply
+	Ceil Expr `json:"ceil"`
+}
+
+func (fn ceilFn) String() string { return printFn(fn) }
+
+// Cos computes the Cosine of a number
+//
+// Parameters:
+//  value number - A number to compute the cosine of
+//
+// Returns:
+//  number - The cosine of value
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
+func Cos(value interface{}) Expr { return cosFn{Cos: wrap(value)} }
+
+type cosFn struct {
+	fnApply
+	Cos Expr `json:"cos"`
+}
+
+func (fn cosFn) String() string { return printFn(fn) }
+
+// Cosh computes the Hyperbolic Cosine of a number
+//
+// Parameters:
+//  value number - A number to compute the Hyperbolic cosine of
+//
+// Returns:
+//  number - The Hyperbolic cosine of value
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
+func Cosh(value interface{}) Expr { return coshFn{Cosh: wrap(value)} }
+
+type coshFn struct {
+	fnApply
+	Cosh Expr `json:"cosh"`
+}
+
+func (fn coshFn) String() string { return printFn(fn) }
+
+// Degrees computes the degress of a number
+//
+// Parameters:
+//  value number - A number to compute the degress of
+//
+// Returns:
+//  number - The degrees of value
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
+func Degrees(value interface{}) Expr { return degreesFn{Degrees: wrap(value)} }
+
+type degreesFn struct {
+	fnApply
+	Degrees Expr `json:"degrees"`
+}
+
+func (fn degreesFn) String() string { return printFn(fn) }
+
+// Divide computes the quotient of a list of numbers.
+//
+// Parameters:
+//  args []number - A collection of numbers to compute the quotient of.
+//
+// Returns:
+//  number - The quotient of all elements.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
+func Divide(args ...interface{}) Expr { return divideFn{Divide: wrap(varargs(args...))} }
+
+type divideFn struct {
+	fnApply
+	Divide Expr `json:"divide" faunarepr:"varargs"`
+}
+
+func (fn divideFn) String() string { return printFn(fn) }
+
+// Exp computes the Exp of a number
+//
+// Parameters:
+//  value number - A number to compute the exp of
+//
+// Returns:
+//  number - The exp of value
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
+func Exp(value interface{}) Expr { return expFn{Exp: wrap(value)} }
+
+type expFn struct {
+	fnApply
+	Exp Expr `json:"exp"`
+}
+
+func (fn expFn) String() string { return printFn(fn) }
+
+// Floor computes the Floor of a number
+//
+// Parameters:
+//  value number - A number to compute the Floor of
+//
+// Returns:
+//  number - The Floor of value
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
+func Floor(value interface{}) Expr { return floorFn{Floor: wrap(value)} }
+
+type floorFn struct {
+	fnApply
+	Floor Expr `json:"floor"`
+}
+
+func (fn floorFn) String() string { return printFn(fn) }
+
+// Hypot computes the Hypotenuse of two numbers
+//
+// Parameters:
+//  a number - A side of a right triangle
+//  b number - A side of a right triangle
+//
+// Returns:
+//  number - The hypotenuse of value
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
+func Hypot(a, b interface{}) Expr { return hypotFn{Hypot: wrap(a), B: wrap(b)} }
+
+type hypotFn struct {
+	fnApply
+	Hypot Expr `json:"hypot"`
+	B     Expr `json:"b"`
+}
+
+func (fn hypotFn) String() string { return printFn(fn) }
+
+// Ln computes the natural log of a number
+//
+// Parameters:
+//  value number - A number to compute the natural log of
+//
+// Returns:
+//  number - The ln of value
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
+func Ln(value interface{}) Expr { return lnFn{Ln: wrap(value)} }
+
+type lnFn struct {
+	fnApply
+	Ln Expr `json:"ln"`
+}
+
+func (fn lnFn) String() string { return printFn(fn) }
+
+// Log computes the Log of a number
+//
+// Parameters:
+//  value number - A number to compute the Log of
+//
+// Returns:
+//  number - The Log of value
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
+func Log(value interface{}) Expr { return logFn{Log: wrap(value)} }
+
+type logFn struct {
+	fnApply
+	Log Expr `json:"log"`
+}
+
+func (fn logFn) String() string { return printFn(fn) }
+
+// Max computes the max of a list of numbers.
+//
+// Parameters:
+//  args []number - A collection of numbers to find the max of.
+//
+// Returns:
+//  number - The max of all elements.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
+func Max(args ...interface{}) Expr { return maxFn{Max: wrap(varargs(args...))} }
+
+type maxFn struct {
+	fnApply
+	Max Expr `json:"max" faunarepr:"varargs"`
+}
+
+func (fn maxFn) String() string { return printFn(fn) }
+
+// Min computes the Min of a list of numbers.
+//
+// Parameters:
+//  args []number - A collection of numbers to find the min of.
+//
+// Returns:
+//  number - The min of all elements.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
+func Min(args ...interface{}) Expr { return minFn{Min: wrap(varargs(args...))} }
+
+type minFn struct {
+	fnApply
+	Min Expr `json:"min" faunarepr:"varargs"`
+}
+
+func (fn minFn) String() string { return printFn(fn) }
+
+// Modulo computes the reminder after the division of a list of numbers.
+//
+// Parameters:
+//  args []number - A collection of numbers to compute the quotient of. The remainder will be returned.
+//
+// Returns:
+//  number - The remainder of the quotient of all elements.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
+func Modulo(args ...interface{}) Expr { return moduloFn{Modulo: wrap(varargs(args...))} }
+
+type moduloFn struct {
+	fnApply
+	Modulo Expr `json:"modulo" faunarepr:"varargs"`
+}
+
+func (fn moduloFn) String() string { return printFn(fn) }
+
+// Multiply computes the product of a list of numbers.
+//
+// Parameters:
+//  args []number - A collection of numbers to multiply together.
+//
+// Returns:
+//  number - The multiplication of all elements.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
+func Multiply(args ...interface{}) Expr { return multiplyFn{Multiply: wrap(varargs(args...))} }
+
+type multiplyFn struct {
+	fnApply
+	Multiply Expr `json:"multiply" faunarepr:"varargs"`
+}
+
+func (fn multiplyFn) String() string { return printFn(fn) }
+
+// Pow computes the Power of a number
+//
+// Parameters:
+//  base number - A number which is the base
+//  exp number  - A number which is the exponent
+//
+// Returns:
+//  number - The Pow of value
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
+func Pow(base, exp interface{}) Expr { return powFn{Pow: wrap(base), Exp: wrap(exp)} }
+
+type powFn struct {
+	fnApply
+	Exp Expr `json:"exp"`
+	Pow Expr `json:"pow"`
+}
+
+func (fn powFn) String() string { return printFn(fn) }
+
+// Radians computes the Radians of a number
+//
+// Parameters:
+//  value number - A number which is convert to radians
+//
+// Returns:
+//  number - The Radians of value
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
+func Radians(value interface{}) Expr { return radiansFn{Radians: wrap(value)} }
+
+type radiansFn struct {
+	fnApply
+	Radians Expr `json:"radians"`
+}
+
+func (fn radiansFn) String() string { return printFn(fn) }
+
+// Round a number at the given percission
+//
+// Parameters:
+//  value number - The number to truncate
+//  precision number - precision where to truncate, defaults is 2
+//
+// Returns:
+//  number - The Rounded value.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
+func Round(value interface{}, options ...OptionalParameter) Expr {
+	fn := roundFn{Round: wrap(value)}
+	return applyOptionals(fn, options)
+}
+
+type roundFn struct {
+	fnApply
+	Round     Expr `json:"round"`
+	Precision Expr `json:"precision,omitempty" faunarepr:"optfn"`
+}
+
+func (fn roundFn) String() string { return printFn(fn) }
+
+// Sign computes the Sign of a number
+//
+// Parameters:
+//  value number - A number to compute the Sign of
+//
+// Returns:
+//  number - The Sign of value
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
+func Sign(value interface{}) Expr { return signFn{Sign: wrap(value)} }
+
+type signFn struct {
+	fnApply
+	Sign Expr `json:"sign"`
+}
+
+func (fn signFn) String() string { return printFn(fn) }
+
+// Sin computes the Sine of a number
+//
+// Parameters:
+//  value number - A number to compute the Sine of
+//
+// Returns:
+//  number - The Sine of value
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
+func Sin(value interface{}) Expr { return sinFn{Sin: wrap(value)} }
+
+type sinFn struct {
+	fnApply
+	Sin Expr `json:"sin"`
+}
+
+func (fn sinFn) String() string { return printFn(fn) }
+
+// Sinh computes the Hyperbolic Sine of a number
+//
+// Parameters:
+//  value number - A number to compute the Hyperbolic Sine of
+//
+// Returns:
+//  number - The Hyperbolic Sine of value
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
+func Sinh(value interface{}) Expr { return sinhFn{Sinh: wrap(value)} }
+
+type sinhFn struct {
+	fnApply
+	Sinh Expr `json:"sinh"`
+}
+
+func (fn sinhFn) String() string { return printFn(fn) }
+
+// Sqrt computes the square root of a number
+//
+// Parameters:
+//  value number - A number to compute the square root of
+//
+// Returns:
+//  number - The square root of value
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
+func Sqrt(value interface{}) Expr { return sqrtFn{Sqrt: wrap(value)} }
+
+type sqrtFn struct {
+	fnApply
+	Sqrt Expr `json:"sqrt"`
+}
+
+func (fn sqrtFn) String() string { return printFn(fn) }
+
+// Subtract computes the difference of a list of numbers.
+//
+// Parameters:
+//  args []number - A collection of numbers to compute the difference of.
+//
+// Returns:
+//  number - The difference of all elements.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
+func Subtract(args ...interface{}) Expr { return subtractFn{Subtract: wrap(varargs(args...))} }
+
+type subtractFn struct {
+	fnApply
+	Subtract Expr `json:"subtract" faunarepr:"varargs"`
+}
+
+func (fn subtractFn) String() string { return printFn(fn) }
+
+// Tan computes the Tangent of a number
+//
+// Parameters:
+//  value number - A number to compute the Tangent of
+//
+// Returns:
+//  number - The Tangent of value
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
+func Tan(value interface{}) Expr { return tanFn{Tan: wrap(value)} }
+
+type tanFn struct {
+	fnApply
+	Tan Expr `json:"tan"`
+}
+
+func (fn tanFn) String() string { return printFn(fn) }
+
+// Tanh computes the Hyperbolic Tangent of a number
+//
+// Parameters:
+//  value number - A number to compute the Hyperbolic Tangent of
+//
+// Returns:
+//  number - The Hyperbolic Tangent of value
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
+func Tanh(value interface{}) Expr { return tanhFn{Tanh: wrap(value)} }
+
+type tanhFn struct {
+	fnApply
+	Tanh Expr `json:"tanh"`
+}
+
+func (fn tanhFn) String() string { return printFn(fn) }
+
+// Trunc truncates a number at the given percission
+//
+// Parameters:
+//  value number - The number to truncate
+//  precision number - precision where to truncate, defaults is 2
+//
+// Returns:
+//  number - The truncated value.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
+func Trunc(value interface{}, options ...OptionalParameter) Expr {
+	fn := truncFn{Trunc: wrap(value)}
+	return applyOptionals(fn, options)
+}
+
+type truncFn struct {
+	fnApply
+	Trunc     Expr `json:"trunc"`
+	Precision Expr `json:"precision,omitempty" faunarepr:"optfn"`
+}
+
+func (fn truncFn) String() string { return printFn(fn) }

--- a/faunadb/functions_read.go
+++ b/faunadb/functions_read.go
@@ -1,0 +1,105 @@
+package faunadb
+
+// Read
+
+// Get retrieves the document identified by the provided ref. Optional parameters: TS.
+//
+// Parameters:
+//  ref Ref|SetRef - The reference to the object or a set reference.
+//
+// Optional parameters:
+//  ts time - The snapshot time at which to get the document. See TS() function.
+//
+// Returns:
+//  Object - The object requested.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#read-functions
+func Get(ref interface{}, options ...OptionalParameter) Expr {
+	fn := getFn{Get: wrap(ref)}
+	return applyOptionals(fn, options)
+}
+
+type getFn struct {
+	fnApply
+	Get Expr `json:"get"`
+	TS  Expr `json:"ts,omitempty" faunarepr:"optfn"`
+}
+
+func (fn getFn) String() string { return printFn(fn) }
+
+// KeyFromSecret retrieves the key object from the given secret.
+//
+// Parameters:
+//  secret string - The token secret.
+//
+// Returns:
+//  Key - The key object related to the token secret.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#read-functions
+func KeyFromSecret(secret interface{}) Expr { return keyFromSecretFn{KeyFromSecret: wrap(secret)} }
+
+type keyFromSecretFn struct {
+	fnApply
+	KeyFromSecret Expr `json:"key_from_secret"`
+}
+
+func (fn keyFromSecretFn) String() string { return printFn(fn) }
+
+// Exists returns boolean true if the provided ref exists (in the case of an document),
+// or is non-empty (in the case of a set), and false otherwise. Optional parameters: TS.
+//
+// Parameters:
+//  ref Ref - The reference to the object. It could be a document reference of a object reference like a collection.
+//
+// Optional parameters:
+//  ts time - The snapshot time at which to check for the document's existence. See TS() function.
+//
+// Returns:
+//  bool - true if the reference exists, false otherwise.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#read-functions
+func Exists(ref interface{}, options ...OptionalParameter) Expr {
+	fn := existsFn{Exists: wrap(ref)}
+	return applyOptionals(fn, options)
+}
+
+type existsFn struct {
+	fnApply
+	Exists Expr `json:"exists"`
+	TS     Expr `json:"ts,omitempty" faunarepr:"optfn"`
+}
+
+func (fn existsFn) String() string { return printFn(fn) }
+
+// Paginate retrieves a page from the provided set.
+//
+// Parameters:
+//  set SetRef - A set reference to paginate over. See Match() or MatchTerm() functions.
+//
+// Optional parameters:
+//  after Cursor - Return the next page of results after this cursor (inclusive). See After() function.
+//  before Cursor - Return the previous page of results before this cursor (exclusive). See Before() function.
+//  sources bool - If true, include the source sets along with each element. See Sources() function.
+//  ts time - The snapshot time at which to get the document. See TS() function.
+//
+// Returns:
+//  Page - A page of elements.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#read-functions
+func Paginate(set interface{}, options ...OptionalParameter) Expr {
+	fn := paginateFn{Paginate: wrap(set)}
+	return applyOptionals(fn, options)
+}
+
+type paginateFn struct {
+	fnApply
+	Paginate Expr `json:"paginate"`
+	After    Expr `json:"after,omitempty" faunarepr:"optfn"`
+	Before   Expr `json:"before,omitempty" faunarepr:"optfn"`
+	Events   Expr `json:"events,omitempty" faunarepr:"fn=optfn,name=EventsOpt"`
+	Size     Expr `json:"size,omitempty" faunarepr:"optfn"`
+	Sources  Expr `json:"sources,omitempty" faunarepr:"optfn"`
+	TS       Expr `json:"ts,omitempty" faunarepr:"optfn"`
+}
+
+func (fn paginateFn) String() string { return printFn(fn) }

--- a/faunadb/functions_ref.go
+++ b/faunadb/functions_ref.go
@@ -1,0 +1,578 @@
+package faunadb
+
+// Ref
+
+// Ref creates a new RefV value with the provided ID.
+//
+// Parameters:
+//  idOrRef Ref - A class reference or string repr to reference type.
+//  id string - The document ID.
+//
+// Returns:
+//  Ref - A new reference type.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#special-type
+func Ref(idOrRef interface{}, id ...interface{}) Expr {
+	switch len(id) {
+	case 0:
+		return legacyRefFn{Ref: wrap(idOrRef)}
+	case 1:
+		return RefCollection(idOrRef, id[0])
+	default:
+		panic("Ref() accepts between 1 and 2 arguments.")
+	}
+}
+
+type legacyRefFn struct {
+	fnApply
+	Ref Expr `json:"@ref"`
+}
+
+func (fn legacyRefFn) String() string { return printFn(fn) }
+
+// RefClass creates a new Ref based on the provided class and ID.
+//
+// Parameters:
+//  classRef Ref - A class reference.
+//  id string|int64 - The document ID.
+//
+// Deprecated: Use RefCollection instead, RefClass is kept for backwards compatibility
+//
+// Returns:
+//  Ref - A new reference type.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#special-type
+func RefClass(classRef, id interface{}) Expr { return refFn{Ref: wrap(classRef), ID: wrap(id)} }
+
+type refFn struct {
+	fnApply
+	Ref Expr `json:"ref"`
+	ID  Expr `json:"id,omitempty"`
+}
+
+func (fn refFn) String() string { return printFn(fn) }
+
+// RefCollection creates a new Ref based on the provided collection and ID.
+//
+// Parameters:
+//  collectionRef Ref - A collection reference.
+//  id string|int64 - The document ID.
+//
+// Returns:
+//  Ref - A new reference type.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#special-type
+func RefCollection(collectionRef, id interface{}) Expr {
+	return refFn{Ref: wrap(collectionRef), ID: wrap(id)}
+}
+
+// Null creates a NullV value.
+//
+// Returns:
+//  Value - A null value.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#simple-type
+func Null() Expr { return NullV{} }
+
+// Database creates a new database ref.
+//
+// Parameters:
+//  name string - The name of the database.
+//
+// Returns:
+//  Ref - The database reference.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
+func Database(name interface{}) Expr { return databaseFn{Database: wrap(name), Scope: nil} }
+
+type databaseFn struct {
+	fnApply
+	Database Expr `json:"database"`
+	Scope    Expr `json:"scope,omitempty" faunarepr:"scopedfn"`
+}
+
+func (fn databaseFn) String() string { return printFn(fn) }
+
+// ScopedDatabase creates a new database ref inside a database.
+//
+// Parameters:
+//  name string - The name of the database.
+//  scope Ref - The reference of the database's scope.
+//
+// Returns:
+//  Ref - The database reference.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
+func ScopedDatabase(name interface{}, scope interface{}) Expr {
+	return databaseFn{
+		Database: wrap(name),
+		Scope:    wrap(scope),
+	}
+}
+
+// Index creates a new index ref.
+//
+// Parameters:
+//  name string - The name of the index.
+//
+// Returns:
+//  Ref - The index reference.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
+func Index(name interface{}) Expr { return indexFn{Index: wrap(name)} }
+
+type indexFn struct {
+	fnApply
+	Index Expr `json:"index"`
+	Scope Expr `json:"scope,omitempty" faunarepr:"scopedfn"`
+}
+
+func (fn indexFn) String() string { return printFn(fn) }
+
+// ScopedIndex creates a new index ref inside a database.
+//
+// Parameters:
+//  name string - The name of the index.
+//  scope Ref - The reference of the index's scope.
+//
+// Returns:
+//  Ref - The index reference.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
+func ScopedIndex(name interface{}, scope interface{}) Expr {
+	return indexFn{
+		Index: wrap(name),
+		Scope: wrap(scope),
+	}
+}
+
+// Class creates a new class ref.
+//
+// Parameters:
+//  name string - The name of the class.
+//
+// Deprecated: Use Collection instead, Class is kept for backwards compatibility
+//
+// Returns:
+//  Ref - The class reference.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
+func Class(name interface{}) Expr { return classFn{Class: wrap(name)} }
+
+type classFn struct {
+	fnApply
+	Class Expr `json:"class"`
+	Scope Expr `json:"scope,omitempty" faunarepr:"scopedfn"`
+}
+
+func (fn classFn) String() string { return printFn(fn) }
+
+// Collection creates a new collection ref.
+//
+// Parameters:
+//  name string - The name of the collection.
+//
+// Returns:
+//  Ref - The collection reference.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
+func Collection(name interface{}) Expr { return collectionFn{Collection: wrap(name)} }
+
+type collectionFn struct {
+	fnApply
+	Collection Expr `json:"collection"`
+	Scope      Expr `json:"scope,omitempty" faunarepr:"scopedfn"`
+}
+
+func (fn collectionFn) String() string { return printFn(fn) }
+
+//Documents returns a set of all documents in the given collection.
+// A set must be paginated in order to retrieve its values.
+//
+// Parameters:
+// collection  ref  - a reference to the collection
+//
+// Returns:
+// Expr  - A new Expr instance
+//
+// See:  https://docs.fauna.com/fauna/current/api/fql/functions/Documents
+func Documents(collection interface{}) Expr {
+	return documentsFn{Documents: wrap(collection)}
+}
+
+type documentsFn struct {
+	fnApply
+	Documents Expr `json:"documents"`
+}
+
+func (fn documentsFn) String() string { return printFn(fn) }
+
+// ScopedClass creates a new class ref inside a database.
+//
+// Parameters:
+//  name string - The name of the class.
+//  scope Ref - The reference of the class's scope.
+//
+// Deprecated: Use ScopedCollection instead, ScopedClass is kept for backwards compatibility
+//
+// Returns:
+//  Ref - The collection reference.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
+func ScopedClass(name interface{}, scope interface{}) Expr {
+	return classFn{Class: wrap(name), Scope: wrap(scope)}
+}
+
+// ScopedCollection creates a new collection ref inside a database.
+//
+// Parameters:
+//  name string - The name of the collection.
+//  scope Ref - The reference of the collection's scope.
+//
+// Returns:
+//  Ref - The collection reference.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
+func ScopedCollection(name interface{}, scope interface{}) Expr {
+	return collectionFn{Collection: wrap(name), Scope: wrap(scope)}
+}
+
+// Function create a new function ref.
+//
+// Parameters:
+//  name string - The name of the functions.
+//
+// Returns:
+//  Ref - The function reference.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
+func Function(name interface{}) Expr { return functionFn{Function: wrap(name)} }
+
+type functionFn struct {
+	fnApply
+	Function Expr `json:"function"`
+	Scope    Expr `json:"scope,omitempty" faunarepr:"scopedfn"`
+}
+
+func (fn functionFn) String() string { return printFn(fn) }
+
+// ScopedFunction creates a new function ref inside a database.
+//
+// Parameters:
+//  name string - The name of the function.
+//  scope Ref - The reference of the function's scope.
+//
+// Returns:
+//  Ref - The function reference.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
+func ScopedFunction(name interface{}, scope interface{}) Expr {
+	return functionFn{Function: wrap(name), Scope: wrap(scope)}
+}
+
+// Role create a new role ref.
+//
+// Parameters:
+//  name string - The name of the role.
+//
+// Returns:
+//  Ref - The role reference.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
+func Role(name interface{}) Expr { return roleFn{Role: wrap(name)} }
+
+type roleFn struct {
+	fnApply
+	Role  Expr `json:"role"`
+	Scope Expr `json:"scope,omitempty" faunarepr:"scopedfn"`
+}
+
+func (fn roleFn) String() string { return printFn(fn) }
+
+// ScopedRole create a new role ref.
+//
+// Parameters:
+//  name string - The name of the role.
+//  scope Ref - The reference of the role's scope.
+//
+// Returns:
+//  Ref - The role reference.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
+func ScopedRole(name, scope interface{}) Expr { return roleFn{Role: wrap(name), Scope: wrap(scope)} }
+
+// Classes creates a native ref for classes.
+//
+// Deprecated: Use Collections instead, Classes is kept for backwards compatibility
+//
+// Returns:
+//  Ref - The reference of the class set.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
+func Classes() Expr { return classesFn{Classes: NullV{}} }
+
+type classesFn struct {
+	fnApply
+	Classes Expr `json:"classes" faunarepr:"scopedfn"`
+}
+
+func (fn classesFn) String() string { return printFn(fn) }
+
+// Collections creates a native ref for collections.
+//
+// Returns:
+//  Ref - The reference of the collections set.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
+func Collections() Expr { return collectionsFn{Collections: NullV{}} }
+
+type collectionsFn struct {
+	fnApply
+	Collections Expr `json:"collections" faunarepr:"scopedfn"`
+}
+
+func (fn collectionsFn) String() string { return printFn(fn) }
+
+// ScopedClasses creates a native ref for classes inside a database.
+//
+// Parameters:
+//  scope Ref - The reference of the class set's scope.
+//
+// Deprecated: Use ScopedCollections instead, ScopedClasses is kept for backwards compatibility
+//
+// Returns:
+//  Ref - The reference of the class set.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
+func ScopedClasses(scope interface{}) Expr { return classesFn{Classes: wrap(scope)} }
+
+// ScopedCollections creates a native ref for collections inside a database.
+//
+// Parameters:
+//  scope Ref - The reference of the collections set's scope.
+//
+// Returns:
+//  Ref - The reference of the collections set.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
+func ScopedCollections(scope interface{}) Expr {
+	return collectionsFn{Collections: wrap(scope)}
+}
+
+// Indexes creates a native ref for indexes.
+//
+// Returns:
+//  Ref - The reference of the index set.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
+func Indexes() Expr { return indexesFn{Indexes: NullV{}} }
+
+type indexesFn struct {
+	fnApply
+	Indexes Expr `json:"indexes" faunarepr:"scopedfn"`
+}
+
+func (fn indexesFn) String() string { return printFn(fn) }
+
+// ScopedIndexes creates a native ref for indexes inside a database.
+//
+// Parameters:
+//  scope Ref - The reference of the index set's scope.
+//
+// Returns:
+//  Ref - The reference of the index set.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
+func ScopedIndexes(scope interface{}) Expr { return indexesFn{Indexes: wrap(scope)} }
+
+// Databases creates a native ref for databases.
+//
+// Returns:
+//  Ref - The reference of the datbase set.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
+func Databases() Expr { return databasesFn{Databases: NullV{}} }
+
+type databasesFn struct {
+	fnApply
+	Databases Expr `json:"databases" faunarepr:"scopedfn"`
+}
+
+func (fn databasesFn) String() string { return printFn(fn) }
+
+// ScopedDatabases creates a native ref for databases inside a database.
+//
+// Parameters:
+//  scope Ref - The reference of the database set's scope.
+//
+// Returns:
+//  Ref - The reference of the database set.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
+func ScopedDatabases(scope interface{}) Expr { return databasesFn{Databases: wrap(scope)} }
+
+// Functions creates a native ref for functions.
+//
+// Returns:
+//  Ref - The reference of the function set.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
+func Functions() Expr { return functionsFn{Functions: NullV{}} }
+
+type functionsFn struct {
+	fnApply
+	Functions Expr `json:"functions" faunarepr:"scopedfn"`
+}
+
+func (fn functionsFn) String() string { return printFn(fn) }
+
+// ScopedFunctions creates a native ref for functions inside a database.
+//
+// Parameters:
+//  scope Ref - The reference of the function set's scope.
+//
+// Returns:
+//  Ref - The reference of the function set.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
+func ScopedFunctions(scope interface{}) Expr { return functionsFn{Functions: wrap(scope)} }
+
+// Roles creates a native ref for roles.
+//
+// Returns:
+//  Ref - The reference of the roles set.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
+func Roles() Expr { return rolesFn{Roles: NullV{}} }
+
+type rolesFn struct {
+	fnApply
+	Roles Expr `json:"roles" faunarepr:"scopedfn"`
+}
+
+func (fn rolesFn) String() string { return printFn(fn) }
+
+// ScopedRoles creates a native ref for roles inside a database.
+//
+// Parameters:
+//  scope Ref - The reference of the role set's scope.
+//
+// Returns:
+//  Ref - The reference of the role set.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
+func ScopedRoles(scope interface{}) Expr { return rolesFn{Roles: wrap(scope)} }
+
+// Keys creates a native ref for keys.
+//
+// Returns:
+//  Ref - The reference of the key set.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
+func Keys() Expr { return keysFn{Keys: NullV{}} }
+
+type keysFn struct {
+	fnApply
+	Keys Expr `json:"keys" faunarepr:"scopedfn"`
+}
+
+func (fn keysFn) String() string { return printFn(fn) }
+
+// ScopedKeys creates a native ref for keys inside a database.
+//
+// Parameters:
+//  scope Ref - The reference of the key set's scope.
+//
+// Returns:
+//  Ref - The reference of the key set.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
+func ScopedKeys(scope interface{}) Expr { return keysFn{Keys: wrap(scope)} }
+
+// Tokens creates a native ref for tokens.
+//
+// Returns:
+//  Ref - The reference of the token set.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
+func Tokens() Expr { return tokensFn{Tokens: NullV{}} }
+
+type tokensFn struct {
+	fnApply
+	Tokens Expr `json:"tokens" faunarepr:"scopedfn"`
+}
+
+func (fn tokensFn) String() string { return printFn(fn) }
+
+// ScopedTokens creates a native ref for tokens inside a database.
+//
+// Parameters:
+//  scope Ref - The reference of the token set's scope.
+//
+// Returns:
+//  Ref - The reference of the token set.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
+func ScopedTokens(scope interface{}) Expr { return tokensFn{Tokens: wrap(scope)} }
+
+// Credentials creates a native ref for credentials.
+//
+// Returns:
+//  Ref - The reference of the credential set.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
+func Credentials() Expr { return credentialsFn{Credentials: NullV{}} }
+
+// ScopedCredentials creates a native ref for credentials inside a database.
+//
+// Parameters:
+//  scope Ref - The reference of the credential set's scope.
+//
+// Returns:
+//  Ref - The reference of the credential set.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
+func ScopedCredentials(scope interface{}) Expr {
+	return credentialsFn{Credentials: wrap(scope)}
+}
+
+type credentialsFn struct {
+	fnApply
+	Credentials Expr `json:"credentials" faunarepr:"scopedfn"`
+}
+
+func (fn credentialsFn) String() string { return printFn(fn) }
+
+// Miscellaneous
+
+// NextID produces a new identifier suitable for use when constructing refs.
+//
+// Deprecated: Use NewId instead
+//
+// Returns:
+//  string - The new ID.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
+func NextID() Expr { return nextIDFn{NextID: NullV{}} }
+
+type nextIDFn struct {
+	fnApply
+	NextID Expr `json:"next_id" faunarepr:"noargs"`
+}
+
+func (fn nextIDFn) String() string { return printFn(fn) }
+
+// NewId produces a new identifier suitable for use when constructing refs.
+//
+// Returns:
+//  string - The new ID.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
+func NewId() Expr { return newIDFn{NewId: NullV{}} }
+
+type newIDFn struct {
+	fnApply
+	NewId Expr `json:"new_id" faunarepr:"noargs"`
+}
+
+func (fn newIDFn) String() string { return printFn(fn) }

--- a/faunadb/functions_sets.go
+++ b/faunadb/functions_sets.go
@@ -1,0 +1,246 @@
+package faunadb
+
+// Set
+
+// Singleton returns the history of the document's presence of the provided ref.
+//
+// Parameters:
+//  ref Ref - The reference of the document for which to retrieve the singleton set.
+//
+// Returns:
+//  SetRef - The singleton SetRef.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#sets
+func Singleton(ref interface{}) Expr { return singletonFn{Singleton: wrap(ref)} }
+
+type singletonFn struct {
+	fnApply
+	Singleton Expr `json:"singleton"`
+}
+
+func (fn singletonFn) String() string { return printFn(fn) }
+
+// Events returns the history of document's data of the provided ref.
+//
+// Parameters:
+//  refSet Ref|SetRef - A reference or set reference to retrieve an event set from.
+//
+// Returns:
+//  SetRef - The events SetRef.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#sets
+func Events(refSet interface{}) Expr { return eventsFn{Events: wrap(refSet)} }
+
+type eventsFn struct {
+	fnApply
+	Events Expr `json:"events"`
+}
+
+func (fn eventsFn) String() string { return printFn(fn) }
+
+// Match returns the set of documents for the specified index.
+//
+// Parameters:
+//  ref Ref - The reference of the index to match against.
+//
+// Returns:
+//  SetRef
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#sets
+func Match(ref interface{}) Expr { return matchFn{Match: wrap(ref), Terms: nil} }
+
+type matchFn struct {
+	fnApply
+	Match Expr `json:"match"`
+	Terms Expr `json:"terms,omitempty"`
+}
+
+func (fn matchFn) String() string {
+	if fn.Terms != nil {
+		return "MatchTerm(" + fn.Match.String() + ", " + fn.Terms.String() + ")"
+	}
+	return printFn(fn)
+}
+
+// MatchTerm returns th set of documents that match the terms in an index.
+//
+// Parameters:
+//  ref Ref - The reference of the index to match against.
+//  terms []Value - A list of terms used in the match.
+//
+// Returns:
+//  SetRef
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#sets
+func MatchTerm(ref, terms interface{}) Expr { return matchFn{Match: wrap(ref), Terms: wrap(terms)} }
+
+// Union returns the set of documents that are present in at least one of the specified sets.
+//
+// Parameters:
+//  sets []SetRef - A list of SetRef to union together.
+//
+// Returns:
+//  SetRef
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#sets
+func Union(sets ...interface{}) Expr { return unionFn{Union: wrap(varargs(sets...))} }
+
+type unionFn struct {
+	fnApply
+	Union Expr `json:"union" faunarepr:"varargs"`
+}
+
+func (fn unionFn) String() string { return printFn(fn) }
+
+// Merge two or more objects..
+//
+// Parameters:
+//   merge merge the first object.
+//   with the second object or a list of objects
+//   lambda a lambda to resolve possible conflicts
+//
+// Returns:
+// merged object
+//
+func Merge(merge interface{}, with interface{}, lambda ...OptionalParameter) Expr {
+	fn := mergeFn{Merge: wrap(merge), With: wrap(with)}
+	return applyOptionals(fn, lambda)
+}
+
+type mergeFn struct {
+	fnApply
+	Merge  Expr `json:"merge"`
+	With   Expr `json:"with"`
+	Lambda Expr `json:"lambda,omitempty" faunarepr:"optfn,name=ConflictResolver"`
+}
+
+func (fn mergeFn) String() string { return printFn(fn) }
+
+// Reduce function applies a reducer Lambda function serially to each member of the collection to produce a single value.
+//
+// Parameters:
+// lambda     Expr  - The accumulator function
+// initial    Expr  - The initial value
+// collection Expr  - The collection to be reduced
+//
+// Returns:
+// Expr
+//
+// See: https://docs.fauna.com/fauna/current/api/fql/functions/reduce
+func Reduce(lambda, initial interface{}, collection interface{}) Expr {
+	return reduceFn{
+		Reduce:     wrap(lambda),
+		Initial:    wrap(initial),
+		Collection: wrap(collection),
+	}
+}
+
+type reduceFn struct {
+	fnApply
+	Reduce     Expr `json:"reduce"`
+	Initial    Expr `json:"initial"`
+	Collection Expr `json:"collection"`
+}
+
+func (fn reduceFn) String() string { return printFn(fn) }
+
+// Intersection returns the set of documents that are present in all of the specified sets.
+//
+// Parameters:
+//  sets []SetRef - A list of SetRef to intersect.
+//
+// Returns:
+//  SetRef
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#sets
+func Intersection(sets ...interface{}) Expr {
+	return intersectionFn{Intersection: wrap(varargs(sets...))}
+}
+
+type intersectionFn struct {
+	fnApply
+	Intersection Expr `json:"intersection" faunarepr:"varargs"`
+}
+
+func (fn intersectionFn) String() string { return printFn(fn) }
+
+// Difference returns the set of documents that are present in the first set but not in
+// any of the other specified sets.
+//
+// Parameters:
+//  sets []SetRef - A list of SetRef to diff.
+//
+// Returns:
+//  SetRef
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#sets
+func Difference(sets ...interface{}) Expr { return differenceFn{Difference: wrap(varargs(sets...))} }
+
+type differenceFn struct {
+	fnApply
+	Difference Expr `json:"difference" faunarepr:"varargs"`
+}
+
+func (fn differenceFn) String() string { return printFn(fn) }
+
+// Distinct returns the set of documents with duplicates removed.
+//
+// Parameters:
+//  set []SetRef - A list of SetRef to remove duplicates from.
+//
+// Returns:
+//  SetRef
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#sets
+func Distinct(set interface{}) Expr { return distinctFn{Distinct: wrap(set)} }
+
+type distinctFn struct {
+	fnApply
+	Distinct Expr `json:"distinct"`
+}
+
+func (fn distinctFn) String() string { return printFn(fn) }
+
+// Join derives a set of resources by applying each document in the source set to the target set.
+//
+// Parameters:
+//  source SetRef - A SetRef of the source set.
+//  target Lambda - A Lambda that will accept each element of the source Set and return a Set.
+//
+// Returns:
+//  SetRef
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#sets
+func Join(source, target interface{}) Expr { return joinFn{Join: wrap(source), With: wrap(target)} }
+
+type joinFn struct {
+	fnApply
+	Join Expr `json:"join"`
+	With Expr `json:"with"`
+}
+
+func (fn joinFn) String() string { return printFn(fn) }
+
+// Range filters the set based on the lower/upper bounds (inclusive).
+//
+// Parameters:
+//  set SetRef - Set to be filtered.
+//  from - lower bound.
+//  to - upper bound
+//
+// Returns:
+//  SetRef
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#sets
+func Range(set interface{}, from interface{}, to interface{}) Expr {
+	return rangeFn{Range: wrap(set), From: wrap(from), To: wrap(to)}
+}
+
+type rangeFn struct {
+	fnApply
+	Range Expr `json:"range"`
+	From  Expr `json:"from"`
+	To    Expr `json:"to"`
+}
+
+func (fn rangeFn) String() string { return printFn(fn) }

--- a/faunadb/functions_strings.go
+++ b/faunadb/functions_strings.go
@@ -1,0 +1,495 @@
+package faunadb
+
+// String
+
+// Format formats values into a string.
+//
+// Parameters:
+//  format string - format a string with format specifiers.
+//
+// Optional parameters:
+//  values []string - list of values to format into string.
+//
+// Returns:
+//  string - A string.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#string-functions
+func Format(format interface{}, values ...interface{}) Expr {
+	return formatFn{Format: wrap(format), Values: wrap(varargs(values...))}
+}
+
+type formatFn struct {
+	fnApply
+	Format Expr `json:"format"`
+	Values Expr `json:"values"`
+}
+
+func (fn formatFn) String() string { return printFn(fn) }
+
+// Concat concatenates a list of strings into a single string.
+//
+// Parameters:
+//  terms []string - A list of strings to concatenate.
+//
+// Optional parameters:
+//  separator string - The separator to use between each string. See Separator() function.
+//
+// Returns:
+//  string - A string with all terms concatenated.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#string-functions
+func Concat(terms interface{}, options ...OptionalParameter) Expr {
+	fn := concatFn{Concat: wrap(terms)}
+	return applyOptionals(fn, options)
+}
+
+type concatFn struct {
+	fnApply
+	Concat    Expr `json:"concat"`
+	Separator Expr `json:"separator,omitempty" faunarepr:"optfn"`
+}
+
+func (fn concatFn) String() string { return printFn(fn) }
+
+// Casefold normalizes strings according to the Unicode Standard section 5.18 "Case Mappings".
+//
+// Parameters:
+//  str string - The string to casefold.
+//
+// Optional parameters:
+//  normalizer string - The algorithm to use. One of: NormalizerNFKCCaseFold, NormalizerNFC, NormalizerNFD, NormalizerNFKC, NormalizerNFKD.
+//
+// Returns:
+//  string - The normalized string.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#string-functions
+func Casefold(str interface{}, options ...OptionalParameter) Expr {
+	fn := casefoldFn{Casefold: wrap(str)}
+	return applyOptionals(fn, options)
+}
+
+type casefoldFn struct {
+	fnApply
+	Casefold   Expr `json:"casefold"`
+	Normalizer Expr `json:"normalizer,omitempty" faunarepr:"optfn"`
+}
+
+func (fn casefoldFn) String() string { return printFn(fn) }
+
+// StartsWith returns true if the string starts with the given prefix value, or false if otherwise
+//
+// Parameters:
+//
+//  value  string -  the string to evaluate
+//  search string -  the prefix to search for
+//
+// Returns:
+//   boolean       - does `value` start with `search
+//
+// See https://docs.fauna.com/fauna/current/api/fql/functions/startswith
+func StartsWith(value interface{}, search interface{}) Expr {
+	return startsWithFn{StartsWith: wrap(value), Search: wrap(search)}
+}
+
+type startsWithFn struct {
+	fnApply
+	StartsWith Expr `json:"startswith"`
+	Search     Expr `json:"search"`
+}
+
+func (fn startsWithFn) String() string { return printFn(fn) }
+
+// EndsWith returns true if the string ends with the given suffix value, or false if otherwise
+//
+// Parameters:
+//
+// value  string  -  the string to evaluate
+// search  string -  the suffix to search for
+//
+// Returns:
+// boolean       - does `value` end with `search`
+//
+// See https://docs.fauna.com/fauna/current/api/fql/functions/endswith
+func EndsWith(value interface{}, search interface{}) Expr {
+	return endsWithFn{EndsWith: wrap(value), Search: wrap(search)}
+}
+
+type endsWithFn struct {
+	fnApply
+	EndsWith Expr `json:"endswith"`
+	Search   Expr `json:"search"`
+}
+
+func (fn endsWithFn) String() string { return printFn(fn) }
+
+// ContainsStr returns true if the string contains the given substring, or false if otherwise
+//
+// Parameters:
+//
+// value string  -  the string to evaluate
+// search string -  the substring to search for
+//
+// Returns:
+// boolean      - was the search result found
+//
+// See https://docs.fauna.com/fauna/current/api/fql/functions/containsstr
+func ContainsStr(value interface{}, search interface{}) Expr {
+	return containsStrFn{ContainsStr: wrap(value), Search: wrap(search)}
+}
+
+type containsStrFn struct {
+	fnApply
+	ContainsStr Expr `json:"containsstr"`
+	Search      Expr `json:"search"`
+}
+
+func (fn containsStrFn) String() string { return printFn(fn) }
+
+// ContainsStrRegex returns true if the string contains the given pattern, or false if otherwise
+//
+// Parameters:
+//
+// value   string      -  the string to evaluate
+// pattern string      -  the pattern to search for
+//
+// Returns:
+// boolean      - was the search result found
+//
+// See https://docs.fauna.com/fauna/current/api/fql/functions/containsstrregex
+func ContainsStrRegex(value interface{}, pattern interface{}) Expr {
+	return containsStrRegexFn{ContainsStrRegex: wrap(value), Pattern: wrap(pattern)}
+}
+
+type containsStrRegexFn struct {
+	fnApply
+	ContainsStrRegex Expr `json:"containsstrregex"`
+	Pattern          Expr `json:"pattern"`
+}
+
+func (fn containsStrRegexFn) String() string { return printFn(fn) }
+
+// RegexEscape It takes a string and returns a regex which matches the input string verbatim.
+//
+// Parameters:
+//
+// value  string     - the string to analyze
+// pattern       -  the pattern to search for
+//
+// Returns:
+// boolean      - was the search result found
+//
+// See https://docs.fauna.com/fauna/current/api/fql/functions/regexescape
+func RegexEscape(value interface{}) Expr {
+	return regexEscapeFn{RegexEscape: wrap(value)}
+}
+
+type regexEscapeFn struct {
+	fnApply
+	RegexEscape Expr `json:"regexescape"`
+}
+
+func (fn regexEscapeFn) String() string { return printFn(fn) }
+
+// FindStr locates a substring in a source string.  Optional parameters: Start
+//
+// Parameters:
+//  str string  - The source string
+//  find string - The string to locate
+//
+// Optional parameters:
+//  start int - a position to start the search. See Start() function.
+//
+// Returns:
+//  string - The offset of where the substring starts or -1 if not found
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#string-functions
+func FindStr(str, find interface{}, options ...OptionalParameter) Expr {
+	fn := findStrFn{FindStr: wrap(str), Find: wrap(find)}
+	return applyOptionals(fn, options)
+}
+
+type findStrFn struct {
+	fnApply
+	FindStr Expr `json:"findstr"`
+	Find    Expr `json:"find"`
+	Start   Expr `json:"start,omitempty" faunarepr:"optfn"`
+}
+
+func (fn findStrFn) String() string { return printFn(fn) }
+
+// FindStrRegex locates a java regex pattern in a source string.  Optional parameters: Start
+//
+// Parameters:
+//  str string      - The sourcestring
+//  pattern string  - The pattern to locate.
+//
+// Optional parameters:
+//  start long - a position to start the search.  See Start() function.
+//
+// Returns:
+//  string - The offset of where the substring starts or -1 if not found
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#string-functions
+func FindStrRegex(str, pattern interface{}, options ...OptionalParameter) Expr {
+	return findStrRegexFn{FindStrRegex: wrap(str), Pattern: wrap(pattern)}
+}
+
+type findStrRegexFn struct {
+	fnApply
+	FindStrRegex Expr `json:"findstrregex"`
+	Pattern      Expr `json:"pattern"`
+}
+
+func (fn findStrRegexFn) String() string { return printFn(fn) }
+
+// Length finds the length of a string in codepoints
+//
+// Parameters:
+//  str string - A string to find the length in codepoints
+//
+// Returns:
+//  int - A length of a string.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#string-functions
+func Length(str interface{}) Expr { return lengthFn{Length: wrap(str)} }
+
+type lengthFn struct {
+	fnApply
+	Length Expr `json:"length"`
+}
+
+func (fn lengthFn) String() string { return printFn(fn) }
+
+// LowerCase changes all characters in the string to lowercase
+//
+// Parameters:
+//  str string - A string to convert to lowercase
+//
+// Returns:
+//  string - A string in lowercase.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#string-functions
+func LowerCase(str interface{}) Expr { return lowercaseFn{Lowercase: wrap(str)} }
+
+type lowercaseFn struct {
+	fnApply
+	Lowercase Expr `json:"lowercase"`
+}
+
+func (fn lowercaseFn) String() string { return printFn(fn) }
+
+// LTrim returns a string wtih leading white space removed.
+//
+// Parameters:
+//  str string - A string to remove leading white space
+//
+// Returns:
+//  string - A string with all leading white space removed
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#string-functions
+func LTrim(str interface{}) Expr { return lTrimFn{LTrim: wrap(str)} }
+
+type lTrimFn struct {
+	fnApply
+	LTrim Expr `json:"ltrim"`
+}
+
+func (fn lTrimFn) String() string { return printFn(fn) }
+
+// Repeat returns a string wtih repeated n times
+//
+// Parameters:
+//  str string - A string to repeat
+//  number int - The number of times to repeat the string
+//
+// Returns:
+//  string - A string concatendanted the specified number of times
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#string-functions
+func Repeat(str, number interface{}) Expr { return repeatFn{Repeat: wrap(str), Number: wrap(number)} }
+
+type repeatFn struct {
+	fnApply
+	Repeat Expr `json:"repeat"`
+	Number Expr `json:"number"`
+}
+
+func (fn repeatFn) String() string { return printFn(fn) }
+
+// ReplaceStr returns a string with every occurence of the "find" string changed to "replace" string
+//
+// Parameters:
+//  str string     - A source string
+//  find string    - The substring to locate in in the source string
+//  replace string - The string to replaice the "find" string when located
+//
+// Returns:
+//  string - returns a string with every occurence of the "find" string changed to "replace"
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#string-functions
+func ReplaceStr(str, find, replace interface{}) Expr {
+	return replaceStrFn{
+		ReplaceStr: wrap(str),
+		Find:       wrap(find),
+		Replace:    wrap(replace),
+	}
+}
+
+type replaceStrFn struct {
+	fnApply
+	ReplaceStr Expr `json:"replacestr"`
+	Find       Expr `json:"find"`
+	Replace    Expr `json:"replace"`
+}
+
+func (fn replaceStrFn) String() string { return printFn(fn) }
+
+// ReplaceStrRegex returns a string with occurence(s) of the java regular expression "pattern" changed to "replace" string.   Optional parameters: OnlyFirst
+//
+// Parameters:
+//  value string   - The source string
+//  pattern string - A java regular expression to locate
+//  replace string - The string to replace the pattern when located
+//
+// Optional parameters:
+//  OnlyFirst - Only replace the first found pattern.  See OnlyFirst() function.
+//
+// Returns:
+//  string - A string with occurence(s) of the java regular expression "pattern" changed to "replace" string
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#string-functions
+func ReplaceStrRegex(value, pattern, replace interface{}, options ...OptionalParameter) Expr {
+	fn := replaceStrRegexFn{
+		ReplaceStrRegex: wrap(value),
+		Pattern:         wrap(pattern),
+		Replace:         wrap(replace),
+	}
+	return applyOptionals(fn, options)
+}
+
+type replaceStrRegexFn struct {
+	fnApply
+	ReplaceStrRegex Expr `json:"replacestrregex"`
+	Pattern         Expr `json:"pattern"`
+	Replace         Expr `json:"replace"`
+	First           Expr `json:"first,omitempty" faunarepr:"fn=optfn,name=OnlyFirst,noargs=true"`
+}
+
+func (fn replaceStrRegexFn) String() string { return printFn(fn) }
+
+// RTrim returns a string wtih trailing white space removed.
+//
+// Parameters:
+//  str string - A string to remove trailing white space
+//
+// Returns:
+//  string - A string with all trailing white space removed
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#string-functions
+func RTrim(str interface{}) Expr { return rTrimFn{RTrim: wrap(str)} }
+
+type rTrimFn struct {
+	fnApply
+	RTrim Expr `json:"rtrim"`
+}
+
+func (fn rTrimFn) String() string { return printFn(fn) }
+
+// Space function returns "N" number of spaces
+//
+// Parameters:
+//  value int - the number of spaces
+//
+// Returns:
+//  string - function returns string with n spaces
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#string-functions
+func Space(value interface{}) Expr { return spaceFn{Space: wrap(value)} }
+
+type spaceFn struct {
+	fnApply
+	Space Expr `json:"space"`
+}
+
+func (fn spaceFn) String() string { return printFn(fn) }
+
+// SubString returns a subset of the source string.   Optional parameters: StrLength
+//
+// Parameters:
+//  str string - A source string
+//  start int  - The position in the source string where SubString starts extracting characters
+//
+// Optional parameters:
+//  StrLength int - A value for the length of the extracted substring. See StrLength() function.
+//
+// Returns:
+//  string - function returns a subset of the source string
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#string-functions
+func SubString(str, start interface{}, options ...OptionalParameter) Expr {
+	fn := subStringFn{SubString: wrap(str), Start: wrap(start)}
+	return applyOptionals(fn, options)
+}
+
+type subStringFn struct {
+	fnApply
+	SubString Expr `json:"substring"`
+	Start     Expr `json:"start"`
+	Length    Expr `json:"length,omitempty" faunarepr:"fn=optfn,name=StrLength"`
+}
+
+func (fn subStringFn) String() string { return printFn(fn) }
+
+// TitleCase changes all characters in the string to TitleCase
+//
+// Parameters:
+//  str string - A string to convert to TitleCase
+//
+// Returns:
+//  string - A string in TitleCase.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#string-functions
+func TitleCase(str interface{}) Expr { return titleCaseFn{Titlecase: wrap(str)} }
+
+type titleCaseFn struct {
+	fnApply
+	Titlecase Expr `json:"titlecase"`
+}
+
+func (fn titleCaseFn) String() string { return printFn(fn) }
+
+// Trim returns a string wtih trailing white space removed.
+//
+// Parameters:
+//  str string - A string to remove trailing white space
+//
+// Returns:
+//  string - A string with all trailing white space removed
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#string-functions
+func Trim(str interface{}) Expr { return trimFn{Trim: wrap(str)} }
+
+type trimFn struct {
+	fnApply
+	Trim Expr `json:"trim"`
+}
+
+func (fn trimFn) String() string { return printFn(fn) }
+
+// UpperCase changes all characters in the string to uppercase
+//
+// Parameters:
+//  string - A string to convert to uppercase
+//
+// Returns:
+//  string - A string in uppercase.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#string-functions
+func UpperCase(str interface{}) Expr { return upperCaseFn{UpperCase: wrap(str)} }
+
+type upperCaseFn struct {
+	fnApply
+	UpperCase Expr `json:"uppercase"`
+}
+
+func (fn upperCaseFn) String() string { return printFn(fn) }

--- a/faunadb/functions_types.go
+++ b/faunadb/functions_types.go
@@ -1,0 +1,488 @@
+package faunadb
+
+// ToString attempts to convert an expression to a string literal.
+//
+// Parameters:
+//   value Object - The expression to convert.
+//
+// Returns:
+//   string - A string literal.
+func ToString(value interface{}) Expr {
+	return toStringFn{ToString: wrap(value)}
+}
+
+type toStringFn struct {
+	fnApply
+	ToString Expr `json:"to_string"`
+}
+
+func (fn toStringFn) String() string { return printFn(fn) }
+
+// ToNumber attempts to convert an expression to a numeric literal -
+// either an int64 or float64.
+//
+// Parameters:
+//   value Object - The expression to convert.
+//
+// Returns:
+//   number - A numeric literal.
+func ToNumber(value interface{}) Expr {
+	return toNumberFn{ToNumber: wrap(value)}
+}
+
+type toNumberFn struct {
+	fnApply
+	ToNumber Expr `json:"to_number"`
+}
+
+func (fn toNumberFn) String() string { return printFn(fn) }
+
+// ToTime attempts to convert an expression to a time literal.
+//
+// Parameters:
+//    value Object - The expression to convert.
+//
+// Returns:
+//   time - A time literal.
+func ToTime(value interface{}) Expr {
+	return toTimeFn{ToTime: wrap(value)}
+}
+
+type toTimeFn struct {
+	fnApply
+	ToTime Expr `json:"to_time"`
+}
+
+func (fn toTimeFn) String() string { return printFn(fn) }
+
+// ToDate attempts to convert an expression to a date literal.
+//
+// Parameters:
+//    value Object - The expression to convert.
+//
+// Returns:
+//   date - A date literal.
+func ToDate(value interface{}) Expr {
+	return toDateFn{ToDate: wrap(value)}
+}
+
+type toDateFn struct {
+	fnApply
+	ToDate Expr `json:"to_date"`
+}
+
+func (fn toDateFn) String() string { return printFn(fn) }
+
+// IsNumber checks if the expression is a number
+//
+// Parameters:
+//  expr Expr - The expression to check.
+//
+// Returns:
+//  bool      -  returns true if the expression is a number
+func IsNumber(expr interface{}) Expr {
+	return isNumberFn{IsNumber: wrap(expr)}
+}
+
+type isNumberFn struct {
+	fnApply
+	IsNumber Expr `json:"is_number"`
+}
+
+func (fn isNumberFn) String() string { return printFn(fn) }
+
+// IsDouble checks if the expression is a double
+//
+// Parameters:
+//  expr Expr - The expression to check.
+//
+// Returns:
+//  bool         -  returns true if the expression is a double
+func IsDouble(expr interface{}) Expr {
+	return isDoubleFn{IsDouble: wrap(expr)}
+}
+
+type isDoubleFn struct {
+	fnApply
+	IsDouble Expr `json:"is_double"`
+}
+
+func (fn isDoubleFn) String() string { return printFn(fn) }
+
+// IsInteger checks if the expression is an integer
+//
+// Parameters:
+//  expr Expr - The expression to check.
+//
+// Returns:
+//  bool         -  returns true if the expression is an integer
+func IsInteger(expr interface{}) Expr {
+	return isIntegerFn{IsInteger: wrap(expr)}
+}
+
+type isIntegerFn struct {
+	fnApply
+	IsInteger Expr `json:"is_integer"`
+}
+
+func (fn isIntegerFn) String() string { return printFn(fn) }
+
+// IsBoolean checks if the expression is a boolean
+//
+// Parameters:
+//  expr Expr - The expression to check.
+//
+// Returns:
+//  bool         -  returns true if the expression is a boolean
+func IsBoolean(expr interface{}) Expr {
+	return isBooleanFn{IsBoolean: wrap(expr)}
+}
+
+type isBooleanFn struct {
+	fnApply
+	IsBoolean Expr `json:"is_boolean"`
+}
+
+func (fn isBooleanFn) String() string { return printFn(fn) }
+
+// IsNull checks if the expression is null
+//
+// Parameters:
+//  expr Expr - The expression to check.
+//
+// Returns:
+//  bool         -  returns true if the expression is null
+func IsNull(expr interface{}) Expr {
+	return isNullFn{IsNull: wrap(expr)}
+}
+
+type isNullFn struct {
+	fnApply
+	IsNull Expr `json:"is_null"`
+}
+
+func (fn isNullFn) String() string { return printFn(fn) }
+
+// IsBytes checks if the expression are bytes
+//
+// Parameters:
+//  expr Expr - The expression to check.
+//
+// Returns:
+//  bool         -  returns true if the expression are bytes
+func IsBytes(expr interface{}) Expr {
+	return isBytesFn{IsBytes: wrap(expr)}
+}
+
+type isBytesFn struct {
+	fnApply
+	IsBytes Expr `json:"is_bytes"`
+}
+
+func (fn isBytesFn) String() string { return printFn(fn) }
+
+// IsTimestamp checks if the expression is a timestamp
+//
+// Parameters:
+//  expr Expr - The expression to check.
+//
+// Returns:
+//  bool         -  returns true if the expression is a timestamp
+func IsTimestamp(expr interface{}) Expr {
+	return isTimestampFn{IsTimestamp: wrap(expr)}
+}
+
+type isTimestampFn struct {
+	fnApply
+	IsTimestamp Expr `json:"is_timestamp"`
+}
+
+func (fn isTimestampFn) String() string { return printFn(fn) }
+
+// IsDate checks if the expression is a date
+//
+// Parameters:
+//  expr Expr - The expression to check.
+//
+// Returns:
+//  bool         -  returns true if the expression is a date
+func IsDate(expr interface{}) Expr {
+	return isDateFn{IsDate: wrap(expr)}
+}
+
+type isDateFn struct {
+	fnApply
+	IsDate Expr `json:"is_date"`
+}
+
+func (fn isDateFn) String() string { return printFn(fn) }
+
+// IsString checks if the expression is a string
+//
+// Parameters:
+//  expr Expr - The expression to check.
+//
+// Returns:
+//  bool         -  returns true if the expression is a string
+func IsString(expr interface{}) Expr {
+	return isStringFn{IsString: wrap(expr)}
+}
+
+type isStringFn struct {
+	fnApply
+	IsString Expr `json:"is_string"`
+}
+
+func (fn isStringFn) String() string { return printFn(fn) }
+
+// IsArray checks if the expression is an array
+//
+// Parameters:
+//  expr Expr - The expression to check.
+//
+// Returns:
+//  bool         -  returns true if the expression is an array
+func IsArray(expr interface{}) Expr {
+	return isArrayFn{IsArray: wrap(expr)}
+}
+
+type isArrayFn struct {
+	fnApply
+	IsArray Expr `json:"is_array"`
+}
+
+func (fn isArrayFn) String() string { return printFn(fn) }
+
+// IsObject checks if the expression is an object
+//
+// Parameters:
+//  expr Expr - The expression to check.
+//
+// Returns:
+//  bool         -  returns true if the expression is an object
+func IsObject(expr interface{}) Expr {
+	return isObjectFn{IsObject: wrap(expr)}
+}
+
+type isObjectFn struct {
+	fnApply
+	IsObject Expr `json:"is_object"`
+}
+
+func (fn isObjectFn) String() string { return printFn(fn) }
+
+// IsRef checks if the expression is a ref
+//
+// Parameters:
+//  expr Expr - The expression to check.
+//
+// Returns:
+//  bool         -  returns true if the expression is a ref
+func IsRef(expr interface{}) Expr {
+	return isRefFn{IsRef: wrap(expr)}
+}
+
+type isRefFn struct {
+	fnApply
+	IsRef Expr `json:"is_ref"`
+}
+
+func (fn isRefFn) String() string { return printFn(fn) }
+
+// IsSet checks if the expression is a set
+//
+// Parameters:
+//  expr Expr - The expression to check.
+//
+// Returns:
+//  bool         -  returns true if the expression is a set
+func IsSet(expr interface{}) Expr {
+	return isSetFn{IsSet: wrap(expr)}
+}
+
+type isSetFn struct {
+	fnApply
+	IsSet Expr `json:"is_set"`
+}
+
+func (fn isSetFn) String() string { return printFn(fn) }
+
+// IsDoc checks if the expression is a document
+//
+// Parameters:
+//  expr Expr - The expression to check.
+//
+// Returns:
+//  bool         -  returns true if the expression is a document
+func IsDoc(expr interface{}) Expr {
+	return isDocFn{IsDoc: wrap(expr)}
+}
+
+type isDocFn struct {
+	fnApply
+	IsDoc Expr `json:"is_doc"`
+}
+
+func (fn isDocFn) String() string { return printFn(fn) }
+
+// IsLambda checks if the expression is a Lambda
+//
+// Parameters:
+//  expr Expr - The expression to check.
+//
+// Returns:
+//  bool         -  returns true if the expression is a Lambda
+func IsLambda(expr interface{}) Expr {
+	return isLambdaFn{IsLambda: wrap(expr)}
+}
+
+type isLambdaFn struct {
+	fnApply
+	IsLambda Expr `json:"is_lambda"`
+}
+
+func (fn isLambdaFn) String() string { return printFn(fn) }
+
+// IsCollection checks if the expression is a collection
+//
+// Parameters:
+//  expr Expr - The expression to check.
+//
+// Returns:
+//  bool         -  returns true if the expression is a collection
+func IsCollection(expr interface{}) Expr {
+	return isCollectionFn{IsCollection: wrap(expr)}
+}
+
+type isCollectionFn struct {
+	fnApply
+	IsCollection Expr `json:"is_collection"`
+}
+
+func (fn isCollectionFn) String() string { return printFn(fn) }
+
+// IsDatabase checks if the expression is a database
+//
+// Parameters:
+//  expr Expr - The expression to check.
+//
+// Returns:
+//  bool         -  returns true if the expression is a database
+func IsDatabase(expr interface{}) Expr {
+	return isDatabaseFn{IsDatabase: wrap(expr)}
+}
+
+type isDatabaseFn struct {
+	fnApply
+	IsDatabase Expr `json:"is_database"`
+}
+
+func (fn isDatabaseFn) String() string { return printFn(fn) }
+
+// IsIndex checks if the expression is an index
+//
+// Parameters:
+//  expr Expr - The expression to check.
+//
+// Returns:
+//  bool         -  returns true if the expression is an index
+func IsIndex(expr interface{}) Expr {
+	return isIndexFn{IsIndex: wrap(expr)}
+}
+
+type isIndexFn struct {
+	fnApply
+	IsIndex Expr `json:"is_index"`
+}
+
+func (fn isIndexFn) String() string { return printFn(fn) }
+
+// IsFunction checks if the expression is a function
+//
+// Parameters:
+//  expr Expr - The expression to check.
+//
+// Returns:
+//  bool         -  returns true if the expression is a function
+func IsFunction(expr interface{}) Expr {
+	return isFunctionFn{IsFunction: wrap(expr)}
+}
+
+type isFunctionFn struct {
+	fnApply
+	IsFunction Expr `json:"is_function"`
+}
+
+func (fn isFunctionFn) String() string { return printFn(fn) }
+
+// IsKey checks if the expression is a key
+//
+// Parameters:
+//  expr Expr - The expression to check.
+//
+// Returns:
+//  bool         -  returns true if the expression is a key
+func IsKey(expr interface{}) Expr {
+	return isKeyFn{IsKey: wrap(expr)}
+}
+
+type isKeyFn struct {
+	fnApply
+	IsKey Expr `json:"is_key"`
+}
+
+func (fn isKeyFn) String() string { return printFn(fn) }
+
+// IsToken checks if the expression is a token
+//
+// Parameters:
+//  expr Expr - The expression to check.
+//
+// Returns:
+//  bool         -  returns true if the expression is a token
+func IsToken(expr interface{}) Expr {
+	return isTokenFn{IsToken: wrap(expr)}
+}
+
+type isTokenFn struct {
+	fnApply
+	IsToken Expr `json:"is_token"`
+}
+
+func (fn isTokenFn) String() string { return printFn(fn) }
+
+// IsCredentials checks if the expression is a credentials
+//
+// Parameters:
+//  expr Expr - The expression to check.
+//
+// Returns:
+//  bool         -  returns true if the expression is a credential
+func IsCredentials(expr interface{}) Expr {
+	return isCredentialsFn{IsCredentials: wrap(expr)}
+}
+
+type isCredentialsFn struct {
+	fnApply
+	IsCredentials Expr `json:"is_credentials"`
+}
+
+func (fn isCredentialsFn) String() string { return printFn(fn) }
+
+// IsRole checks if the expression is a role
+//
+// Parameters:
+//  expr Expr - The expression to check.
+//
+// Returns:
+//  bool         -  returns true if the expression is a role
+func IsRole(expr interface{}) Expr {
+	return isRoleFn{IsRole: wrap(expr)}
+}
+
+type isRoleFn struct {
+	fnApply
+	IsRole Expr `json:"is_role"`
+}
+
+func (fn isRoleFn) String() string { return printFn(fn) }

--- a/faunadb/functions_write.go
+++ b/faunadb/functions_write.go
@@ -1,0 +1,280 @@
+package faunadb
+
+// Write
+
+// Create creates an document of the specified collection.
+//
+// Parameters:
+//  ref Ref - A collection reference.
+//  params Object - An object with attributes of the document created.
+//
+// Returns:
+//  Object - A new document of the collection referenced.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#write-functions
+func Create(ref, params interface{}) Expr { return createFn{Create: wrap(ref), Params: wrap(params)} }
+
+type createFn struct {
+	fnApply
+	Create Expr `json:"create"`
+	Params Expr `json:"params"`
+}
+
+func (fn createFn) String() string { return printFn(fn) }
+
+// CreateClass creates a new class.
+//
+// Parameters:
+//  params Object - An object with attributes of the class.
+//
+// Deprecated: Use CreateCollection instead, CreateClass is kept for backwards compatibility
+//
+// Returns:
+//  Object - The new created class object.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#write-functions
+func CreateClass(params interface{}) Expr { return createClassFn{CreateClass: wrap(params)} }
+
+type createClassFn struct {
+	fnApply
+	CreateClass Expr `json:"create_class"`
+}
+
+func (fn createClassFn) String() string { return printFn(fn) }
+
+// CreateCollection creates a new collection.
+//
+// Parameters:
+//  params Object - An object with attributes of the collection.
+//
+// Returns:
+//  Object - The new created collection object.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#write-functions
+func CreateCollection(params interface{}) Expr {
+	return createCollectionFn{CreateCollection: wrap(params)}
+}
+
+type createCollectionFn struct {
+	fnApply
+	CreateCollection Expr `json:"create_collection"`
+}
+
+func (fn createCollectionFn) String() string { return printFn(fn) }
+
+// CreateDatabase creates an new database.
+//
+// Parameters:
+//  params Object - An object with attributes of the database.
+//
+// Returns:
+//  Object - The new created database object.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#write-functions
+func CreateDatabase(params interface{}) Expr { return createDatabaseFn{CreateDatabase: wrap(params)} }
+
+type createDatabaseFn struct {
+	fnApply
+	CreateDatabase Expr `json:"create_database"`
+}
+
+func (fn createDatabaseFn) String() string { return printFn(fn) }
+
+// CreateIndex creates a new index.
+//
+// Parameters:
+//  params Object - An object with attributes of the index.
+//
+// Returns:
+//  Object - The new created index object.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#write-functions
+func CreateIndex(params interface{}) Expr { return createIndexFn{CreateIndex: wrap(params)} }
+
+type createIndexFn struct {
+	fnApply
+	CreateIndex Expr `json:"create_index"`
+}
+
+func (fn createIndexFn) String() string { return printFn(fn) }
+
+// CreateKey creates a new key.
+//
+// Parameters:
+//  params Object - An object with attributes of the key.
+//
+// Returns:
+//  Object - The new created key object.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#write-functions
+func CreateKey(params interface{}) Expr { return createKeyFn{CreateKey: wrap(params)} }
+
+type createKeyFn struct {
+	fnApply
+	CreateKey Expr `json:"create_key"`
+}
+
+func (fn createKeyFn) String() string { return printFn(fn) }
+
+// CreateFunction creates a new function.
+//
+// Parameters:
+//  params Object - An object with attributes of the function.
+//
+// Returns:
+//  Object - The new created function object.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#write-functions
+func CreateFunction(params interface{}) Expr { return createFunctionFn{CreateFunction: wrap(params)} }
+
+type createFunctionFn struct {
+	fnApply
+	CreateFunction Expr `json:"create_function"`
+}
+
+func (fn createFunctionFn) String() string { return printFn(fn) }
+
+// CreateRole creates a new role.
+//
+// Parameters:
+//  params Object - An object with attributes of the role.
+//
+// Returns:
+//  Object - The new created role object.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#write-functions
+func CreateRole(params interface{}) Expr { return createRoleFn{CreateRole: wrap(params)} }
+
+type createRoleFn struct {
+	fnApply
+	CreateRole Expr `json:"create_role"`
+}
+
+func (fn createRoleFn) String() string { return printFn(fn) }
+
+// MoveDatabase moves a database to a new hierachy.
+//
+// Parameters:
+//  from Object - Source reference to be moved.
+//  to Object   - New parent database reference.
+//
+// Returns:
+//  Object - instance.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#write-functions
+func MoveDatabase(from interface{}, to interface{}) Expr {
+	return moveDatabaseFn{MoveDatabase: wrap(from), To: wrap(to)}
+}
+
+type moveDatabaseFn struct {
+	fnApply
+	MoveDatabase Expr `json:"move_database"`
+	To           Expr `json:"to"`
+}
+
+func (fn moveDatabaseFn) String() string { return printFn(fn) }
+
+// Update updates the provided document.
+//
+// Parameters:
+//  ref Ref - The reference to update.
+//  params Object - An object representing the parameters of the document.
+//
+// Returns:
+//  Object - The updated object.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#write-functions
+func Update(ref, params interface{}) Expr { return updateFn{Update: wrap(ref), Params: wrap(params)} }
+
+type updateFn struct {
+	fnApply
+	Update Expr `json:"update"`
+	Params Expr `json:"params"`
+}
+
+func (fn updateFn) String() string { return printFn(fn) }
+
+// Replace replaces the provided document.
+//
+// Parameters:
+//  ref Ref - The reference to replace.
+//  params Object - An object representing the parameters of the document.
+//
+// Returns:
+//  Object - The replaced object.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#write-functions
+func Replace(ref, params interface{}) Expr { return replaceFn{Replace: wrap(ref), Params: wrap(params)} }
+
+type replaceFn struct {
+	fnApply
+	Replace Expr `json:"replace"`
+	Params  Expr `json:"params"`
+}
+
+func (fn replaceFn) String() string { return printFn(fn) }
+
+// Delete deletes the provided document.
+//
+// Parameters:
+//  ref Ref - The reference to delete.
+//
+// Returns:
+//  Object - The deleted object.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#write-functions
+func Delete(ref interface{}) Expr { return deleteFn{Delete: wrap(ref)} }
+
+type deleteFn struct {
+	fnApply
+	Delete Expr `json:"delete"`
+}
+
+func (fn deleteFn) String() string { return printFn(fn) }
+
+// Insert adds an event to the provided document's history.
+//
+// Parameters:
+//  ref Ref - The reference to insert against.
+//  ts time - The valid time of the inserted event.
+//  action string - Whether the event shoulde be a ActionCreate, ActionUpdate or ActionDelete.
+//
+// Returns:
+//  Object - The deleted object.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#write-functions
+func Insert(ref, ts, action, params interface{}) Expr {
+	return insertFn{Insert: wrap(ref), TS: wrap(ts), Action: wrap(action), Params: wrap(params)}
+}
+
+type insertFn struct {
+	fnApply
+	Insert Expr `json:"insert"`
+	TS     Expr `json:"ts"`
+	Action Expr `json:"action"`
+	Params Expr `json:"params"`
+}
+
+// Remove deletes an event from the provided document's history.
+//
+// Parameters:
+//  ref Ref - The reference of the document whose event should be removed.
+//  ts time - The valid time of the inserted event.
+//  action string - The event action (ActionCreate, ActionUpdate or ActionDelete) that should be removed.
+//
+// Returns:
+//  Object - The deleted object.
+//
+// See: https://app.fauna.com/documentation/reference/queryapi#write-functions
+func Remove(ref, ts, action interface{}) Expr {
+	return removeFn{Remove: wrap(ref), Ts: wrap(ts), Action: wrap(action)}
+}
+
+type removeFn struct {
+	fnApply
+	Remove Expr `json:"remove"`
+	Ts     Expr `json:"ts"`
+	Action Expr `json:"action"`
+}
+
+func (fn removeFn) String() string { return printFn(fn) }

--- a/faunadb/query.go
+++ b/faunadb/query.go
@@ -1,5 +1,24 @@
 package faunadb
 
+type fnApply interface {
+	Expr
+}
+
+// OptionalParameter describes optional parameters for query language functions
+type OptionalParameter func(Expr) Expr
+
+func applyOptionals(expr Expr, options []OptionalParameter) Expr {
+	for _, option := range options {
+		switch expr.(type) {
+		case invalidExpr:
+			return expr
+		default:
+			expr = option(expr)
+		}
+	}
+	return expr
+}
+
 // Event's action types. Usually used as a parameter for Insert or Remove functions.
 //
 // See: https://app.fauna.com/documentation/reference/queryapi#simple-type-events
@@ -57,18 +76,56 @@ func varargs(expr ...interface{}) interface{} {
 // EventsOpt is provided here for backwards compatibility. Instead of using Paginate with the EventsOpt parameter,
 // you should use the new Events function.
 func EventsOpt(events interface{}) OptionalParameter {
-	return func(fn unescapedObj) {
-		fn["events"] = wrap(events)
+	return func(expr Expr) Expr {
+		switch e := expr.(type) {
+		case eventsParam:
+			return e.setEvents(wrap(events))
+		default:
+			return e
+		}
 	}
+}
+
+type eventsParam interface {
+	setEvents(length Expr) Expr
+}
+
+func (fn paginateFn) setEvents(e Expr) Expr {
+	fn.Events = e
+	return fn
 }
 
 // TS is a timestamp optional parameter that specifies in which timestamp a query should be executed.
 //
-// Functions that accept this optional parameter are: Get, Insert, Remove, Exists, and Paginate.
+// Functions that accept this optional parameter are: Get, Exists, and Paginate.
 func TS(timestamp interface{}) OptionalParameter {
-	return func(fn unescapedObj) {
-		fn["ts"] = wrap(timestamp)
+	return func(expr Expr) Expr {
+		switch e := expr.(type) {
+		case tsParam:
+			return e.setTS(wrap(timestamp))
+		default:
+			return e
+		}
 	}
+}
+
+type tsParam interface {
+	setTS(length Expr) Expr
+}
+
+func (fn paginateFn) setTS(e Expr) Expr {
+	fn.TS = e
+	return fn
+}
+
+func (fn existsFn) setTS(e Expr) Expr {
+	fn.TS = e
+	return fn
+}
+
+func (fn getFn) setTS(e Expr) Expr {
+	fn.TS = e
+	return fn
 }
 
 // After is an optional parameter used when cursoring that refers to the specified cursor's the next page, inclusive.
@@ -76,9 +133,23 @@ func TS(timestamp interface{}) OptionalParameter {
 //
 // Functions that accept this optional parameter are: Paginate.
 func After(ref interface{}) OptionalParameter {
-	return func(fn unescapedObj) {
-		fn["after"] = wrap(ref)
+	return func(expr Expr) Expr {
+		switch e := expr.(type) {
+		case afterParam:
+			return e.setAfter(wrap(ref))
+		default:
+			return e
+		}
 	}
+}
+
+type afterParam interface {
+	setAfter(after Expr) Expr
+}
+
+func (fn paginateFn) setAfter(e Expr) Expr {
+	fn.After = e
+	return fn
 }
 
 // Before is an optional parameter used when cursoring that refers to the specified cursor's previous page, exclusive.
@@ -86,45 +157,115 @@ func After(ref interface{}) OptionalParameter {
 //
 // Functions that accept this optional parameter are: Paginate.
 func Before(ref interface{}) OptionalParameter {
-	return func(fn unescapedObj) {
-		fn["before"] = wrap(ref)
+	return func(expr Expr) Expr {
+		switch e := expr.(type) {
+		case beforeParam:
+			return e.setBefore(wrap(ref))
+		default:
+			return e
+		}
 	}
+}
+
+type beforeParam interface {
+	setBefore(before Expr) Expr
+}
+
+func (fn paginateFn) setBefore(e Expr) Expr {
+	fn.Before = e
+	return fn
 }
 
 // Size is a numeric optional parameter that specifies the size of a pagination cursor.
 //
 // Functions that accept this optional parameter are: Paginate.
 func Size(size interface{}) OptionalParameter {
-	return func(fn unescapedObj) {
-		fn["size"] = wrap(size)
+	return func(expr Expr) Expr {
+		switch e := expr.(type) {
+		case sizeParam:
+			return e.setSize(wrap(size))
+		default:
+			return e
+		}
 	}
+}
+
+type sizeParam interface {
+	setSize(size Expr) Expr
+}
+
+func (fn paginateFn) setSize(e Expr) Expr {
+	fn.Size = e
+	return fn
 }
 
 // Start is a numeric optional parameter that specifies the start of where to search.
 //
-// Functions that accept this optional parameter are: FindStr and FindStrRegex.
+// Functions that accept this optional parameter are: FindStr .
 func Start(start interface{}) OptionalParameter {
-	return func(fn unescapedObj) {
-		fn["start"] = wrap(start)
+	return func(expr Expr) Expr {
+		switch e := expr.(type) {
+		case startParam:
+			return e.setStart(wrap(start))
+		default:
+			return e
+		}
 	}
+}
+
+type startParam interface {
+	setStart(start Expr) Expr
+}
+
+func (fn findStrFn) setStart(e Expr) Expr {
+	fn.Start = e
+	return fn
 }
 
 // StrLength is a numeric optional parameter that specifies the amount to copy.
 //
 // Functions that accept this optional parameter are: FindStr and FindStrRegex.
 func StrLength(length interface{}) OptionalParameter {
-	return func(fn unescapedObj) {
-		fn["length"] = wrap(length)
+	return func(expr Expr) Expr {
+		switch e := expr.(type) {
+		case strLengthParam:
+			return e.setLength(wrap(length))
+		default:
+			return e
+		}
 	}
+}
+
+type strLengthParam interface {
+	setLength(length Expr) Expr
+}
+
+func (fn subStringFn) setLength(e Expr) Expr {
+	fn.Length = e
+	return fn
 }
 
 // OnlyFirst is a boolean optional parameter that only replace the first string
 //
 // Functions that accept this optional parameter are: ReplaceStrRegex
 func OnlyFirst() OptionalParameter {
-	return func(fn unescapedObj) {
-		fn["first"] = BooleanV(true)
+	return func(expr Expr) Expr {
+		switch e := expr.(type) {
+		case firstParam:
+			return e.setOnlyFirst()
+		default:
+			return e
+		}
 	}
+}
+
+type firstParam interface {
+	setOnlyFirst() Expr
+}
+
+func (fn replaceStrRegexFn) setOnlyFirst() Expr {
+	fn.First = BooleanV(true)
+	return fn
 }
 
 // Sources is a boolean optional parameter that specifies if a pagination cursor should include
@@ -132,9 +273,23 @@ func OnlyFirst() OptionalParameter {
 //
 // Functions that accept this optional parameter are: Paginate.
 func Sources(sources interface{}) OptionalParameter {
-	return func(fn unescapedObj) {
-		fn["sources"] = wrap(sources)
+	return func(expr Expr) Expr {
+		switch e := expr.(type) {
+		case sourcesParam:
+			return e.setSources(wrap(sources))
+		default:
+			return e
+		}
 	}
+}
+
+type sourcesParam interface {
+	setSources(sources Expr) Expr
+}
+
+func (fn paginateFn) setSources(e Expr) Expr {
+	fn.Sources = e
+	return fn
 }
 
 // Default is an optional parameter that specifies the default value for a select operation when
@@ -142,2545 +297,123 @@ func Sources(sources interface{}) OptionalParameter {
 //
 // Functions that accept this optional parameter are: Select.
 func Default(value interface{}) OptionalParameter {
-	return func(fn unescapedObj) {
-		fn["default"] = wrap(value)
+	return func(expr Expr) Expr {
+		switch e := expr.(type) {
+		case defaultParam:
+			return e.setDefault(wrap(value))
+		default:
+			return e
+		}
 	}
+}
+
+type defaultParam interface {
+	setDefault(value Expr) Expr
+}
+
+func (fn selectFn) setDefault(e Expr) Expr {
+	fn.Default = e
+	return fn
+}
+
+func (fn selectAllFn) setDefault(e Expr) Expr {
+	fn.Default = e
+	return fn
 }
 
 // Separator is a string optional parameter that specifies the separator for a concat operation.
 //
 // Functions that accept this optional parameter are: Concat.
 func Separator(sep interface{}) OptionalParameter {
-	return func(fn unescapedObj) {
-		fn["separator"] = wrap(sep)
+	return func(expr Expr) Expr {
+		switch e := expr.(type) {
+		case separatorParam:
+			return e.setSeparator(wrap(sep))
+		default:
+			return e
+		}
 	}
+}
+
+type separatorParam interface {
+	setSeparator(sep Expr) Expr
+}
+
+func (fn concatFn) setSeparator(e Expr) Expr {
+	fn.Separator = e
+	return fn
 }
 
 // Precision is an optional parameter that specifies the precision for a Trunc and Round operations.
 //
 // Functions that accept this optional parameter are: Round and Trunc.
 func Precision(precision interface{}) OptionalParameter {
-	return func(fn unescapedObj) {
-		fn["precision"] = wrap(precision)
+	return func(expr Expr) Expr {
+		switch e := expr.(type) {
+		case precisionParam:
+			return e.setPrecision(wrap(precision))
+		default:
+			return e
+		}
 	}
+}
+
+type precisionParam interface {
+	setPrecision(precision Expr) Expr
+}
+
+func (fn roundFn) setPrecision(e Expr) Expr {
+	fn.Precision = e
+	return fn
+}
+
+func (fn truncFn) setPrecision(e Expr) Expr {
+	fn.Precision = e
+	return fn
 }
 
 // ConflictResolver is an optional parameter that specifies the lambda for resolving Merge conflicts
 //
 // Functions that accept this optional parameter are: Merge
 func ConflictResolver(lambda interface{}) OptionalParameter {
-	return func(fn unescapedObj) {
-		fn["lambda"] = wrap(lambda)
+	return func(expr Expr) Expr {
+		switch e := expr.(type) {
+		case lambdaParam:
+			return e.setLambda(wrap(lambda))
+		default:
+			return e
+		}
 	}
+}
+
+type lambdaParam interface {
+	setLambda(lambda Expr) Expr
+}
+
+func (fn mergeFn) setLambda(e Expr) Expr {
+	fn.Lambda = e
+	return fn
 }
 
 // Normalizer is a string optional parameter that specifies the normalization function for casefold operation.
 //
 // Functions that accept this optional parameter are: Casefold.
 func Normalizer(norm interface{}) OptionalParameter {
-	return func(fn unescapedObj) {
-		fn["normalizer"] = wrap(norm)
+	return func(expr Expr) Expr {
+		switch e := expr.(type) {
+		case normalizerParam:
+			return e.setNormalizer(wrap(norm))
+		default:
+			return e
+		}
 	}
 }
 
-// LetBuilder builds Let expressions
-type LetBuilder struct {
-	bindings unescapedArr
+type normalizerParam interface {
+	setNormalizer(normalizer Expr) Expr
 }
 
-// Bind binds a variable name to a value and returns a LetBuilder
-func (lb *LetBuilder) Bind(key string, in interface{}) *LetBuilder {
-	binding := make(unescapedObj, 1)
-	binding[key] = wrap(in)
-	lb.bindings = append(lb.bindings, binding)
-	return lb
-}
-
-// In sets the expression to be evaluated and returns the prepared Let.
-func (lb *LetBuilder) In(in Expr) Expr {
-	return fn2("let", lb.bindings, "in", in)
-}
-
-// Values
-
-// Ref creates a new RefV value with the provided ID.
-//
-// Parameters:
-//  idOrRef Ref - A class reference or string repr to reference type.
-//  id string - The document ID.
-//
-// Returns:
-//  Ref - A new reference type.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#special-type
-func Ref(idOrRef interface{}, id ...interface{}) Expr {
-	switch len(id) {
-	case 0:
-		return fn1("@ref", idOrRef)
-	case 1:
-		return RefCollection(idOrRef, id[0])
-	default:
-		panic("Ref() accepts between 1 and 2 arguments.")
-	}
-}
-
-// RefClass creates a new Ref based on the provided class and ID.
-//
-// Parameters:
-//  classRef Ref - A class reference.
-//  id string|int64 - The document ID.
-//
-// Deprecated: Use RefCollection instead, RefClass is kept for backwards compatibility
-//
-// Returns:
-//  Ref - A new reference type.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#special-type
-func RefClass(classRef, id interface{}) Expr { return fn2("ref", classRef, "id", id) }
-
-// RefCollection creates a new Ref based on the provided collection and ID.
-//
-// Parameters:
-//  collectionRef Ref - A collection reference.
-//  id string|int64 - The document ID.
-//
-// Returns:
-//  Ref - A new reference type.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#special-type
-func RefCollection(collectionRef, id interface{}) Expr { return fn2("ref", collectionRef, "id", id) }
-
-// Null creates a NullV value.
-//
-// Returns:
-//  Value - A null value.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#simple-type
-func Null() Expr { return NullV{} }
-
-// Basic forms
-
-// Abort aborts the execution of the query
-//
-// Parameters:
-//  msg string - An error message.
-//
-// Returns:
-//  Error
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#basic-forms
-func Abort(msg interface{}) Expr { return fn1("abort", msg) }
-
-// Do sequentially evaluates its arguments, and returns the last expression.
-// If no expressions are provided, do returns an error.
-//
-// Parameters:
-//  exprs []Expr - A variable number of expressions to be evaluated.
-//
-// Returns:
-//  Value - The result of the last expression in the list.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#basic-forms
-func Do(exprs ...interface{}) Expr { return fn1("do", exprs) }
-
-// If evaluates and returns then or elze depending on the value of cond.
-// If cond evaluates to anything other than a boolean, if returns an “invalid argument” error
-//
-// Parameters:
-//  cond bool - A boolean expression.
-//  then Expr - The expression to run if condition is true.
-//  elze Expr - The expression to run if condition is false.
-//
-// Returns:
-//  Value - The result of either then or elze expression.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#basic-forms
-func If(cond, then, elze interface{}) Expr { return fn3("if", cond, "then", then, "else", elze) }
-
-// Lambda creates an anonymous function. Mostly used with Collection functions.
-//
-// Parameters:
-//  varName string|[]string - A string or an array of strings of arguments name to be bound in the body of the lambda.
-//  expr Expr - An expression used as the body of the lambda.
-//
-// Returns:
-//  Value - The result of the body expression.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#basic-forms
-func Lambda(varName, expr interface{}) Expr { return fn2("lambda", varName, "expr", expr) }
-
-// At execute an expression at a given timestamp.
-//
-// Parameters:
-//  timestamp time - The timestamp in which the expression will be evaluated.
-//  expr Expr - An expression to be evaluated.
-//
-// Returns:
-//  Value - The result of the given expression.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#basic-forms
-func At(timestamp, expr interface{}) Expr { return fn2("at", timestamp, "expr", expr) }
-
-// Let binds values to one or more variables.
-//
-// Returns:
-//  *LetBuilder - Returns a LetBuilder.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#basic-forms
-func Let() *LetBuilder { return &LetBuilder{nil} }
-
-// Var refers to a value of a variable on the current lexical scope.
-//
-// Parameters:
-//  name string - The variable name.
-//
-// Returns:
-//  Value - The variable value.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#basic-forms
-func Var(name string) Expr { return fn1("var", name) }
-
-// Call invokes the specified function passing in a variable number of arguments
-//
-// Parameters:
-//  ref Ref - The reference to the user defined functions to call.
-//  args []Value - A series of values to pass as arguments to the user defined function.
-//
-// Returns:
-//  Value - The return value of the user defined function.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#basic-forms
-func Call(ref interface{}, args ...interface{}) Expr {
-	return fn2("call", ref, "arguments", varargs(args...))
-}
-
-// Query creates an instance of the @query type with the specified lambda
-//
-// Parameters:
-//  lambda Lambda - A lambda representation. See Lambda() function.
-//
-// Returns:
-//  Query - The lambda wrapped in a @query type.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#basic-forms
-func Query(lambda interface{}) Expr { return fn1("query", lambda) }
-
-// Collections
-
-// Map applies the lambda expression on each element of a collection or Page.
-// It returns the result of each application on a collection of the same type.
-//
-// Parameters:
-//  coll []Value - The collection of elements to iterate.
-//  lambda Lambda - A lambda function to be applied to each element of the collection. See Lambda() function.
-//
-// Returns:
-//  []Value - A new collection with elements transformed by the lambda function.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#collections
-func Map(coll, lambda interface{}) Expr { return fn2("map", lambda, "collection", coll) }
-
-// Foreach applies the lambda expression on each element of a collection or Page.
-// The original collection is returned.
-//
-// Parameters:
-//  coll []Value - The collection of elements to iterate.
-//  lambda Lambda - A lambda function to be applied to each element of the collection. See Lambda() function.
-//
-// Returns:
-//  []Value - The original collection.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#collections
-func Foreach(coll, lambda interface{}) Expr { return fn2("foreach", lambda, "collection", coll) }
-
-// Filter applies the lambda expression on each element of a collection or Page.
-// It returns a new collection of the same type containing only the elements in which the
-// function application returned true.
-//
-// Parameters:
-//  coll []Value - The collection of elements to iterate.
-//  lambda Lambda - A lambda function to be applied to each element of the collection. The lambda function must return a boolean value. See Lambda() function.
-//
-// Returns:
-//  []Value - A new collection.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#collections
-func Filter(coll, lambda interface{}) Expr { return fn2("filter", lambda, "collection", coll) }
-
-// Take returns a new collection containing num elements from the head of the original collection.
-//
-// Parameters:
-//  num int64 - The number of elements to take from the collection.
-//  coll []Value - The collection of elements.
-//
-// Returns:
-//  []Value - A new collection.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#collections
-func Take(num, coll interface{}) Expr { return fn2("take", num, "collection", coll) }
-
-// Drop returns a new collection containing the remaining elements from the original collection
-// after num elements have been removed.
-//
-// Parameters:
-//  num int64 - The number of elements to drop from the collection.
-//  coll []Value - The collection of elements.
-//
-// Returns:
-//  []Value - A new collection.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#collections
-func Drop(num, coll interface{}) Expr { return fn2("drop", num, "collection", coll) }
-
-// Prepend returns a new collection that is the result of prepending elems to coll.
-//
-// Parameters:
-//  elems []Value - Elements to add to the beginning of the other collection.
-//  coll []Value - The collection of elements.
-//
-// Returns:
-//  []Value - A new collection.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#collections
-func Prepend(elems, coll interface{}) Expr { return fn2("prepend", elems, "collection", coll) }
-
-// Append returns a new collection that is the result of appending elems to coll.
-//
-// Parameters:
-//  elems []Value - Elements to add to the end of the other collection.
-//  coll []Value - The collection of elements.
-//
-// Returns:
-//  []Value - A new collection.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#collections
-func Append(elems, coll interface{}) Expr { return fn2("append", elems, "collection", coll) }
-
-// IsEmpty returns true if the collection is the empty set, else false.
-//
-// Parameters:
-//  coll []Value - The collection of elements.
-//
-// Returns:
-//   bool - True if the collection is empty, else false.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#collections
-func IsEmpty(coll interface{}) Expr { return fn1("is_empty", coll) }
-
-// IsNonEmpty returns false if the collection is the empty set, else true
-//
-// Parameters:
-//  coll []Value - The collection of elements.
-//
-// Returns:
-//   bool - True if the collection is not empty, else false.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#collections
-func IsNonEmpty(coll interface{}) Expr { return fn1("is_nonempty", coll) }
-
-// Read
-
-// Get retrieves the document identified by the provided ref. Optional parameters: TS.
-//
-// Parameters:
-//  ref Ref|SetRef - The reference to the object or a set reference.
-//
-// Optional parameters:
-//  ts time - The snapshot time at which to get the document. See TS() function.
-//
-// Returns:
-//  Object - The object requested.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#read-functions
-func Get(ref interface{}, options ...OptionalParameter) Expr { return fn1("get", ref, options...) }
-
-// KeyFromSecret retrieves the key object from the given secret.
-//
-// Parameters:
-//  secret string - The token secret.
-//
-// Returns:
-//  Key - The key object related to the token secret.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#read-functions
-func KeyFromSecret(secret interface{}) Expr { return fn1("key_from_secret", secret) }
-
-// Exists returns boolean true if the provided ref exists (in the case of an document),
-// or is non-empty (in the case of a set), and false otherwise. Optional parameters: TS.
-//
-// Parameters:
-//  ref Ref - The reference to the object. It could be a document reference of a object reference like a collection.
-//
-// Optional parameters:
-//  ts time - The snapshot time at which to check for the document's existence. See TS() function.
-//
-// Returns:
-//  bool - true if the reference exists, false otherwise.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#read-functions
-func Exists(ref interface{}, options ...OptionalParameter) Expr { return fn1("exists", ref, options...) }
-
-// Paginate retrieves a page from the provided set.
-//
-// Parameters:
-//  set SetRef - A set reference to paginate over. See Match() or MatchTerm() functions.
-//
-// Optional parameters:
-//  after Cursor - Return the next page of results after this cursor (inclusive). See After() function.
-//  before Cursor - Return the previous page of results before this cursor (exclusive). See Before() function.
-//  sources bool - If true, include the source sets along with each element. See Sources() function.
-//  ts time - The snapshot time at which to get the document. See TS() function.
-//
-// Returns:
-//  Page - A page of elements.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#read-functions
-func Paginate(set interface{}, options ...OptionalParameter) Expr {
-	return fn1("paginate", set, options...)
-}
-
-// Write
-
-// Create creates an document of the specified collection.
-//
-// Parameters:
-//  ref Ref - A collection reference.
-//  params Object - An object with attributes of the document created.
-//
-// Returns:
-//  Object - A new document of the collection referenced.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#write-functions
-func Create(ref, params interface{}) Expr { return fn2("create", ref, "params", params) }
-
-// CreateClass creates a new class.
-//
-// Parameters:
-//  params Object - An object with attributes of the class.
-//
-// Deprecated: Use CreateCollection instead, CreateClass is kept for backwards compatibility
-//
-// Returns:
-//  Object - The new created class object.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#write-functions
-func CreateClass(params interface{}) Expr { return fn1("create_class", params) }
-
-// CreateCollection creates a new collection.
-//
-// Parameters:
-//  params Object - An object with attributes of the collection.
-//
-// Returns:
-//  Object - The new created collection object.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#write-functions
-func CreateCollection(params interface{}) Expr { return fn1("create_collection", params) }
-
-// CreateDatabase creates an new database.
-//
-// Parameters:
-//  params Object - An object with attributes of the database.
-//
-// Returns:
-//  Object - The new created database object.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#write-functions
-func CreateDatabase(params interface{}) Expr { return fn1("create_database", params) }
-
-// CreateIndex creates a new index.
-//
-// Parameters:
-//  params Object - An object with attributes of the index.
-//
-// Returns:
-//  Object - The new created index object.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#write-functions
-func CreateIndex(params interface{}) Expr { return fn1("create_index", params) }
-
-// CreateKey creates a new key.
-//
-// Parameters:
-//  params Object - An object with attributes of the key.
-//
-// Returns:
-//  Object - The new created key object.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#write-functions
-func CreateKey(params interface{}) Expr { return fn1("create_key", params) }
-
-// CreateFunction creates a new function.
-//
-// Parameters:
-//  params Object - An object with attributes of the function.
-//
-// Returns:
-//  Object - The new created function object.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#write-functions
-func CreateFunction(params interface{}) Expr { return fn1("create_function", params) }
-
-// CreateRole creates a new role.
-//
-// Parameters:
-//  params Object - An object with attributes of the role.
-//
-// Returns:
-//  Object - The new created role object.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#write-functions
-func CreateRole(params interface{}) Expr { return fn1("create_role", params) }
-
-// MoveDatabase moves a database to a new hierachy.
-//
-// Parameters:
-//  from Object - Source reference to be moved.
-//  to Object   - New parent database reference.
-//
-// Returns:
-//  Object - instance.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#write-functions
-func MoveDatabase(from interface{}, to interface{}) Expr { return fn2("move_database", from, "to", to) }
-
-// Update updates the provided document.
-//
-// Parameters:
-//  ref Ref - The reference to update.
-//  params Object - An object representing the parameters of the document.
-//
-// Returns:
-//  Object - The updated object.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#write-functions
-func Update(ref, params interface{}) Expr { return fn2("update", ref, "params", params) }
-
-// Replace replaces the provided document.
-//
-// Parameters:
-//  ref Ref - The reference to replace.
-//  params Object - An object representing the parameters of the document.
-//
-// Returns:
-//  Object - The replaced object.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#write-functions
-func Replace(ref, params interface{}) Expr { return fn2("replace", ref, "params", params) }
-
-// Delete deletes the provided document.
-//
-// Parameters:
-//  ref Ref - The reference to delete.
-//
-// Returns:
-//  Object - The deleted object.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#write-functions
-func Delete(ref interface{}) Expr { return fn1("delete", ref) }
-
-// Insert adds an event to the provided document's history.
-//
-// Parameters:
-//  ref Ref - The reference to insert against.
-//  ts time - The valid time of the inserted event.
-//  action string - Whether the event shoulde be a ActionCreate, ActionUpdate or ActionDelete.
-//
-// Returns:
-//  Object - The deleted object.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#write-functions
-func Insert(ref, ts, action, params interface{}) Expr {
-	return fn4("insert", ref, "ts", ts, "action", action, "params", params)
-}
-
-// Remove deletes an event from the provided document's history.
-//
-// Parameters:
-//  ref Ref - The reference of the document whose event should be removed.
-//  ts time - The valid time of the inserted event.
-//  action string - The event action (ActionCreate, ActionUpdate or ActionDelete) that should be removed.
-//
-// Returns:
-//  Object - The deleted object.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#write-functions
-func Remove(ref, ts, action interface{}) Expr { return fn3("remove", ref, "ts", ts, "action", action) }
-
-// String
-
-// Format formats values into a string.
-//
-// Parameters:
-//  format string - format a string with format specifiers.
-//
-// Optional parameters:
-//  values []string - list of values to format into string.
-//
-// Returns:
-//  string - A string.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#string-functions
-func Format(format interface{}, values ...interface{}) Expr {
-	return fn2("format", format, "values", varargs(values...))
-}
-
-// Concat concatenates a list of strings into a single string.
-//
-// Parameters:
-//  terms []string - A list of strings to concatenate.
-//
-// Optional parameters:
-//  separator string - The separator to use between each string. See Separator() function.
-//
-// Returns:
-//  string - A string with all terms concatenated.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#string-functions
-func Concat(terms interface{}, options ...OptionalParameter) Expr {
-	return fn1("concat", terms, options...)
-}
-
-// Casefold normalizes strings according to the Unicode Standard section 5.18 "Case Mappings".
-//
-// Parameters:
-//  str string - The string to casefold.
-//
-// Optional parameters:
-//  normalizer string - The algorithm to use. One of: NormalizerNFKCCaseFold, NormalizerNFC, NormalizerNFD, NormalizerNFKC, NormalizerNFKD.
-//
-// Returns:
-//  string - The normalized string.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#string-functions
-func Casefold(str interface{}, options ...OptionalParameter) Expr {
-	return fn1("casefold", str, options...)
-}
-
-// StartsWith returns true if the string starts with the given prefix value, or false if otherwise
-//
-// Parameters:
-//
-//  value  string -  the string to evaluate
-//  search string -  the prefix to search for
-//
-// Returns:
-//   boolean       - does `value` start with `search
-//
-// See https://docs.fauna.com/fauna/current/api/fql/functions/startswith
-func StartsWith(value interface{}, search interface{}) Expr {
-	return fn2("startswith", value, "search", search)
-}
-
-// EndsWith returns true if the string ends with the given suffix value, or false if otherwise
-//
-// Parameters:
-//
-// value  string  -  the string to evaluate
-// search  string -  the suffix to search for
-//
-// Returns:
-// boolean       - does `value` end with `search`
-//
-// See https://docs.fauna.com/fauna/current/api/fql/functions/endswith
-func EndsWith(value interface{}, search interface{}) Expr {
-	return fn2("endswith", value, "search", search)
-}
-
-// ContainsStr returns true if the string contains the given substring, or false if otherwise
-//
-// Parameters:
-//
-// value string  -  the string to evaluate
-// search string -  the substring to search for
-//
-// Returns:
-// boolean      - was the search result found
-//
-// See https://docs.fauna.com/fauna/current/api/fql/functions/containsstr
-func ContainsStr(value interface{}, search interface{}) Expr {
-	return fn2("containsstr", value, "search", search)
-}
-
-// ContainsStrRegex returns true if the string contains the given pattern, or false if otherwise
-//
-// Parameters:
-//
-// value   string      -  the string to evaluate
-// pattern string      -  the pattern to search for
-//
-// Returns:
-// boolean      - was the search result found
-//
-// See https://docs.fauna.com/fauna/current/api/fql/functions/containsstrregex
-func ContainsStrRegex(value interface{}, pattern interface{}) Expr {
-	return fn2("containsstrregex", value, "pattern", pattern)
-}
-
-// RegexEscape It takes a string and returns a regex which matches the input string verbatim.
-//
-// Parameters:
-//
-// value  string     - the string to analyze
-// pattern       -  the pattern to search for
-//
-// Returns:
-// boolean      - was the search result found
-//
-// See https://docs.fauna.com/fauna/current/api/fql/functions/regexescape
-func RegexEscape(value interface{}) Expr {
-	return fn1("regexescape", value)
-}
-
-// FindStr locates a substring in a source string.  Optional parameters: Start
-//
-// Parameters:
-//  str string  - The source string
-//  find string - The string to locate
-//
-// Optional parameters:
-//  start int - a position to start the search. See Start() function.
-//
-// Returns:
-//  string - The offset of where the substring starts or -1 if not found
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#string-functions
-func FindStr(str, find interface{}, options ...OptionalParameter) Expr {
-	return fn2("findstr", str, "find", find, options...)
-}
-
-// FindStrRegex locates a java regex pattern in a source string.  Optional parameters: Start
-//
-// Parameters:
-//  str string      - The sourcestring
-//  pattern string  - The pattern to locate.
-//
-// Optional parameters:
-//  start long - a position to start the search.  See Start() function.
-//
-// Returns:
-//  string - The offset of where the substring starts or -1 if not found
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#string-functions
-func FindStrRegex(str, pattern interface{}, options ...OptionalParameter) Expr {
-	return fn2("findstrregex", str, "pattern", pattern, options...)
-}
-
-// Length finds the length of a string in codepoints
-//
-// Parameters:
-//  str string - A string to find the length in codepoints
-//
-// Returns:
-//  int - A length of a string.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#string-functions
-func Length(str interface{}) Expr { return fn1("length", str) }
-
-// LowerCase changes all characters in the string to lowercase
-//
-// Parameters:
-//  str string - A string to convert to lowercase
-//
-// Returns:
-//  string - A string in lowercase.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#string-functions
-func LowerCase(str interface{}) Expr { return fn1("lowercase", str) }
-
-// LTrim returns a string wtih leading white space removed.
-//
-// Parameters:
-//  str string - A string to remove leading white space
-//
-// Returns:
-//  string - A string with all leading white space removed
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#string-functions
-func LTrim(str interface{}) Expr { return fn1("ltrim", str) }
-
-// Repeat returns a string wtih repeated n times
-//
-// Parameters:
-//  str string - A string to repeat
-//  number int - The number of times to repeat the string
-//
-// Returns:
-//  string - A string concatendanted the specified number of times
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#string-functions
-func Repeat(str, number interface{}) Expr { return fn2("repeat", str, "number", number) }
-
-// ReplaceStr returns a string with every occurence of the "find" string changed to "replace" string
-//
-// Parameters:
-//  str string     - A source string
-//  find string    - The substring to locate in in the source string
-//  replace string - The string to replaice the "find" string when located
-//
-// Returns:
-//  string - returns a string with every occurence of the "find" string changed to "replace"
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#string-functions
-func ReplaceStr(str, find, replace interface{}) Expr {
-	return fn3("replacestr", str, "find", find, "replace", replace)
-}
-
-// ReplaceStrRegex returns a string with occurence(s) of the java regular expression "pattern" changed to "replace" string.   Optional parameters: OnlyFirst
-//
-// Parameters:
-//  value string   - The source string
-//  pattern string - A java regular expression to locate
-//  replace string - The string to replace the pattern when located
-//
-// Optional parameters:
-//  OnlyFirst - Only replace the first found pattern.  See OnlyFirst() function.
-//
-// Returns:
-//  string - A string with occurence(s) of the java regular expression "pattern" changed to "replace" string
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#string-functions
-func ReplaceStrRegex(value, pattern, replace interface{}, options ...OptionalParameter) Expr {
-	return fn3("replacestrregex", value, "pattern", pattern, "replace", replace, options...)
-}
-
-// RTrim returns a string wtih trailing white space removed.
-//
-// Parameters:
-//  str string - A string to remove trailing white space
-//
-// Returns:
-//  string - A string with all trailing white space removed
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#string-functions
-func RTrim(str interface{}) Expr { return fn1("rtrim", str) }
-
-// Space function returns "N" number of spaces
-//
-// Parameters:
-//  value int - the number of spaces
-//
-// Returns:
-//  string - function returns string with n spaces
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#string-functions
-func Space(value interface{}) Expr { return fn1("space", value) }
-
-// SubString returns a subset of the source string.   Optional parameters: StrLength
-//
-// Parameters:
-//  str string - A source string
-//  start int  - The position in the source string where SubString starts extracting characters
-//
-// Optional parameters:
-//  StrLength int - A value for the length of the extracted substring. See StrLength() function.
-//
-// Returns:
-//  string - function returns a subset of the source string
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#string-functions
-func SubString(str, start interface{}, options ...OptionalParameter) Expr {
-	return fn2("substring", str, "start", start, options...)
-}
-
-// TitleCase changes all characters in the string to TitleCase
-//
-// Parameters:
-//  str string - A string to convert to TitleCase
-//
-// Returns:
-//  string - A string in TitleCase.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#string-functions
-func TitleCase(str interface{}) Expr { return fn1("titlecase", str) }
-
-// Trim returns a string wtih trailing white space removed.
-//
-// Parameters:
-//  str string - A string to remove trailing white space
-//
-// Returns:
-//  string - A string with all trailing white space removed
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#string-functions
-func Trim(str interface{}) Expr { return fn1("trim", str) }
-
-// UpperCase changes all characters in the string to uppercase
-//
-// Parameters:
-//  string - A string to convert to uppercase
-//
-// Returns:
-//  string - A string in uppercase.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#string-functions
-func UpperCase(str interface{}) Expr { return fn1("uppercase", str) }
-
-// Time and Date
-
-// Time constructs a time from a ISO 8601 offset date/time string.
-//
-// Parameters:
-//  str string - A string to convert to a time object.
-//
-// Returns:
-//  time - A time object.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#time-and-date
-func Time(str interface{}) Expr { return fn1("time", str) }
-
-// TimeAdd returns a new time or date with the offset in terms of the unit
-// added.
-//
-// Parameters:
-// base        -  the base time or data
-// offset      -  the number of units
-// unit        -  the unit type
-//
-// Returns:
-// Expr
-//
-//See: https://docs.fauna.com/fauna/current/api/fql/functions/timeadd
-func TimeAdd(base interface{}, offset interface{}, unit interface{}) Expr {
-	return fn3(
-		"time_add", base,
-		"offset", offset,
-		"unit", unit,
-	)
-}
-
-// TimeSubtract returns a new time or date with the offset in terms of the unit
-// subtracted.
-//
-// Parameters:
-// base        -  the base time or data
-// offset      -  the number of units
-// unit        -  the unit type
-//
-// Returns:
-// Expr
-//
-//See: https://docs.fauna.com/fauna/current/api/fql/functions/timesubtract
-func TimeSubtract(base interface{}, offset interface{}, unit interface{}) Expr {
-	return fn3(
-		"time_subtract", base,
-		"offset", offset,
-		"unit", unit,
-	)
-}
-
-// TimeDiff returns the number of intervals in terms of the unit between
-// two times or dates. Both start and finish must be of the same
-// type.
-//
-// Parameters:
-//   start the starting time or date, inclusive
-//   finish the ending time or date, exclusive
-//   unit the unit type//
-// Returns:
-// Expr
-//
-//See: https://docs.fauna.com/fauna/current/api/fql/functions/timediff
-func TimeDiff(start interface{}, finish interface{}, unit interface{}) Expr {
-	return fn3(
-		"time_diff", start,
-		"other", finish,
-		"unit", unit,
-	)
-}
-
-// Date constructs a date from a ISO 8601 offset date/time string.
-//
-// Parameters:
-//  str string - A string to convert to a date object.
-//
-// Returns:
-//  date - A date object.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#time-and-date
-func Date(str interface{}) Expr { return fn1("date", str) }
-
-// Epoch constructs a time relative to the epoch "1970-01-01T00:00:00Z".
-//
-// Parameters:
-//  num int64 - The number of units from Epoch.
-//  unit string - The unit of number. One of TimeUnitSecond, TimeUnitMillisecond, TimeUnitMicrosecond, TimeUnitNanosecond.
-//
-// Returns:
-//  time - A time object.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#time-and-date
-func Epoch(num, unit interface{}) Expr { return fn2("epoch", num, "unit", unit) }
-
-// Now returns the current snapshot time.
-//
-// Returns:
-// Expr
-//
-// See: https://docs.fauna.com/fauna/current/api/fql/functions/now
-func Now() Expr {
-	return fn1("now", NullV{})
-}
-
-// Set
-
-// Singleton returns the history of the document's presence of the provided ref.
-//
-// Parameters:
-//  ref Ref - The reference of the document for which to retrieve the singleton set.
-//
-// Returns:
-//  SetRef - The singleton SetRef.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#sets
-func Singleton(ref interface{}) Expr { return fn1("singleton", ref) }
-
-// Events returns the history of document's data of the provided ref.
-//
-// Parameters:
-//  refSet Ref|SetRef - A reference or set reference to retrieve an event set from.
-//
-// Returns:
-//  SetRef - The events SetRef.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#sets
-func Events(refSet interface{}) Expr { return fn1("events", refSet) }
-
-// Match returns the set of documents for the specified index.
-//
-// Parameters:
-//  ref Ref - The reference of the index to match against.
-//
-// Returns:
-//  SetRef
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#sets
-func Match(ref interface{}) Expr { return fn1("match", ref) }
-
-// MatchTerm returns th set of documents that match the terms in an index.
-//
-// Parameters:
-//  ref Ref - The reference of the index to match against.
-//  terms []Value - A list of terms used in the match.
-//
-// Returns:
-//  SetRef
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#sets
-func MatchTerm(ref, terms interface{}) Expr { return fn2("match", ref, "terms", terms) }
-
-// Union returns the set of documents that are present in at least one of the specified sets.
-//
-// Parameters:
-//  sets []SetRef - A list of SetRef to union together.
-//
-// Returns:
-//  SetRef
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#sets
-func Union(sets ...interface{}) Expr { return fn1("union", varargs(sets...)) }
-
-// Merge two or more objects..
-//
-// Parameters:
-//   merge merge the first object.
-//   with the second object or a list of objects
-//   lambda a lambda to resolve possible conflicts
-//
-// Returns:
-// merged object
-//
-func Merge(merge interface{}, with interface{}, lambda ...OptionalParameter) Expr {
-	return fn2("merge", merge, "with", with, lambda...)
-}
-
-// Reduce function applies a reducer Lambda function serially to each member of the collection to produce a single value.
-//
-// Parameters:
-// lambda     Expr  - The accumulator function
-// initial    Expr  - The initial value
-// collection Expr  - The collection to be reduced
-//
-// Returns:
-// Expr
-//
-// See: https://docs.fauna.com/fauna/current/api/fql/functions/reduce
-func Reduce(lambda, initial interface{}, collection interface{}) Expr {
-	return fn3("reduce", lambda, "initial", initial, "collection", collection)
-}
-
-// Intersection returns the set of documents that are present in all of the specified sets.
-//
-// Parameters:
-//  sets []SetRef - A list of SetRef to intersect.
-//
-// Returns:
-//  SetRef
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#sets
-func Intersection(sets ...interface{}) Expr { return fn1("intersection", varargs(sets...)) }
-
-// Difference returns the set of documents that are present in the first set but not in
-// any of the other specified sets.
-//
-// Parameters:
-//  sets []SetRef - A list of SetRef to diff.
-//
-// Returns:
-//  SetRef
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#sets
-func Difference(sets ...interface{}) Expr { return fn1("difference", varargs(sets...)) }
-
-// Distinct returns the set of documents with duplicates removed.
-//
-// Parameters:
-//  set []SetRef - A list of SetRef to remove duplicates from.
-//
-// Returns:
-//  SetRef
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#sets
-func Distinct(set interface{}) Expr { return fn1("distinct", set) }
-
-// Join derives a set of resources by applying each document in the source set to the target set.
-//
-// Parameters:
-//  source SetRef - A SetRef of the source set.
-//  target Lambda - A Lambda that will accept each element of the source Set and return a Set.
-//
-// Returns:
-//  SetRef
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#sets
-func Join(source, target interface{}) Expr { return fn2("join", source, "with", target) }
-
-// Range filters the set based on the lower/upper bounds (inclusive).
-//
-// Parameters:
-//  set SetRef - Set to be filtered.
-//  from - lower bound.
-//  to - upper bound
-//
-// Returns:
-//  SetRef
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#sets
-func Range(set interface{}, from interface{}, to interface{}) Expr {
-	return fn3("range", set, "from", from, "to", to)
-}
-
-// Authentication
-
-// Login creates a token for the provided ref.
-//
-// Parameters:
-//  ref Ref - A reference with credentials to authenticate against.
-//  params Object - An object of parameters to pass to the login function
-//    - password: The password used to login
-//
-// Returns:
-//  Key - a key with the secret to login.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#authentication
-func Login(ref, params interface{}) Expr { return fn2("login", ref, "params", params) }
-
-// Logout deletes the current session token. If invalidateAll is true, logout will delete all tokens associated with the current session.
-//
-// Parameters:
-//  invalidateAll bool - If true, log out all tokens associated with the current session.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#authentication
-func Logout(invalidateAll interface{}) Expr { return fn1("logout", invalidateAll) }
-
-// Identify checks the given password against the provided ref's credentials.
-//
-// Parameters:
-//  ref Ref - The reference to check the password against.
-//  password string - The credentials password to check.
-//
-// Returns:
-//  bool - true if the password is correct, false otherwise.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#authentication
-func Identify(ref, password interface{}) Expr { return fn2("identify", ref, "password", password) }
-
-// Identity returns the document reference associated with the current key.
-//
-// For example, the current key token created using:
-//	Create(Tokens(), Obj{"document": someRef})
-// or via:
-//	Login(someRef, Obj{"password":"sekrit"})
-// will return "someRef" as the result of this function.
-//
-// Returns:
-//  Ref - The reference associated with the current key.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#authentication
-func Identity() Expr { return fn1("identity", NullV{}) }
-
-// HasIdentity checks if the current key has an identity associated to it.
-//
-// Returns:
-//  bool - true if the current key has an identity, false otherwise.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#authentication
-func HasIdentity() Expr { return fn1("has_identity", NullV{}) }
-
-// Miscellaneous
-
-// NextID produces a new identifier suitable for use when constructing refs.
-//
-// Deprecated: Use NewId instead
-//
-// Returns:
-//  string - The new ID.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
-func NextID() Expr { return fn1("new_id", NullV{}) }
-
-// NewId produces a new identifier suitable for use when constructing refs.
-//
-// Returns:
-//  string - The new ID.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
-func NewId() Expr { return fn1("new_id", NullV{}) }
-
-// Database creates a new database ref.
-//
-// Parameters:
-//  name string - The name of the database.
-//
-// Returns:
-//  Ref - The database reference.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
-func Database(name interface{}) Expr { return fn1("database", name) }
-
-// ScopedDatabase creates a new database ref inside a database.
-//
-// Parameters:
-//  name string - The name of the database.
-//  scope Ref - The reference of the database's scope.
-//
-// Returns:
-//  Ref - The database reference.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
-func ScopedDatabase(name interface{}, scope interface{}) Expr {
-	return fn2("database", name, "scope", scope)
-}
-
-// Index creates a new index ref.
-//
-// Parameters:
-//  name string - The name of the index.
-//
-// Returns:
-//  Ref - The index reference.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
-func Index(name interface{}) Expr { return fn1("index", name) }
-
-// ScopedIndex creates a new index ref inside a database.
-//
-// Parameters:
-//  name string - The name of the index.
-//  scope Ref - The reference of the index's scope.
-//
-// Returns:
-//  Ref - The index reference.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
-func ScopedIndex(name interface{}, scope interface{}) Expr { return fn2("index", name, "scope", scope) }
-
-// Class creates a new class ref.
-//
-// Parameters:
-//  name string - The name of the class.
-//
-// Deprecated: Use Collection instead, Class is kept for backwards compatibility
-//
-// Returns:
-//  Ref - The class reference.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
-func Class(name interface{}) Expr { return fn1("class", name) }
-
-// Collection creates a new collection ref.
-//
-// Parameters:
-//  name string - The name of the collection.
-//
-// Returns:
-//  Ref - The collection reference.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
-func Collection(name interface{}) Expr { return fn1("collection", name) }
-
-//Documents returns a set of all documents in the given collection.
-// A set must be paginated in order to retrieve its values.
-//
-// Parameters:
-// collection  ref  - a reference to the collection
-//
-// Returns:
-// Expr  - A new Expr instance
-//
-// See:  https://docs.fauna.com/fauna/current/api/fql/functions/Documents
-func Documents(collection interface{}) Expr {
-	return fn1("documents", collection)
-}
-
-// ScopedClass creates a new class ref inside a database.
-//
-// Parameters:
-//  name string - The name of the class.
-//  scope Ref - The reference of the class's scope.
-//
-// Deprecated: Use ScopedCollection instead, ScopedClass is kept for backwards compatibility
-//
-// Returns:
-//  Ref - The collection reference.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
-func ScopedClass(name interface{}, scope interface{}) Expr {
-	return fn2("class", name, "scope", scope)
-}
-
-// ScopedCollection creates a new collection ref inside a database.
-//
-// Parameters:
-//  name string - The name of the collection.
-//  scope Ref - The reference of the collection's scope.
-//
-// Returns:
-//  Ref - The collection reference.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
-func ScopedCollection(name interface{}, scope interface{}) Expr {
-	return fn2("collection", name, "scope", scope)
-}
-
-// Function create a new function ref.
-//
-// Parameters:
-//  name string - The name of the functions.
-//
-// Returns:
-//  Ref - The function reference.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
-func Function(name interface{}) Expr { return fn1("function", name) }
-
-// ScopedFunction creates a new function ref inside a database.
-//
-// Parameters:
-//  name string - The name of the function.
-//  scope Ref - The reference of the function's scope.
-//
-// Returns:
-//  Ref - The function reference.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
-func ScopedFunction(name interface{}, scope interface{}) Expr {
-	return fn2("function", name, "scope", scope)
-}
-
-// Role create a new role ref.
-//
-// Parameters:
-//  name string - The name of the role.
-//
-// Returns:
-//  Ref - The role reference.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
-func Role(name interface{}) Expr { return fn1("role", name) }
-
-// ScopedRole create a new role ref.
-//
-// Parameters:
-//  name string - The name of the role.
-//  scope Ref - The reference of the role's scope.
-//
-// Returns:
-//  Ref - The role reference.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
-func ScopedRole(name, scope interface{}) Expr { return fn2("role", name, "scope", scope) }
-
-// Classes creates a native ref for classes.
-//
-// Deprecated: Use Collections instead, Classes is kept for backwards compatibility
-//
-// Returns:
-//  Ref - The reference of the class set.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
-func Classes() Expr { return fn1("classes", NullV{}) }
-
-// Collections creates a native ref for collections.
-//
-// Returns:
-//  Ref - The reference of the collections set.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
-func Collections() Expr { return fn1("collections", NullV{}) }
-
-// ScopedClasses creates a native ref for classes inside a database.
-//
-// Parameters:
-//  scope Ref - The reference of the class set's scope.
-//
-// Deprecated: Use ScopedCollections instead, ScopedClasses is kept for backwards compatibility
-//
-// Returns:
-//  Ref - The reference of the class set.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
-func ScopedClasses(scope interface{}) Expr { return fn1("classes", scope) }
-
-// ScopedCollections creates a native ref for collections inside a database.
-//
-// Parameters:
-//  scope Ref - The reference of the collections set's scope.
-//
-// Returns:
-//  Ref - The reference of the collections set.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
-func ScopedCollections(scope interface{}) Expr { return fn1("collections", scope) }
-
-// Indexes creates a native ref for indexes.
-//
-// Returns:
-//  Ref - The reference of the index set.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
-func Indexes() Expr { return fn1("indexes", NullV{}) }
-
-// ScopedIndexes creates a native ref for indexes inside a database.
-//
-// Parameters:
-//  scope Ref - The reference of the index set's scope.
-//
-// Returns:
-//  Ref - The reference of the index set.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
-func ScopedIndexes(scope interface{}) Expr { return fn1("indexes", scope) }
-
-// Databases creates a native ref for databases.
-//
-// Returns:
-//  Ref - The reference of the datbase set.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
-func Databases() Expr { return fn1("databases", NullV{}) }
-
-// ScopedDatabases creates a native ref for databases inside a database.
-//
-// Parameters:
-//  scope Ref - The reference of the database set's scope.
-//
-// Returns:
-//  Ref - The reference of the database set.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
-func ScopedDatabases(scope interface{}) Expr { return fn1("databases", scope) }
-
-// Functions creates a native ref for functions.
-//
-// Returns:
-//  Ref - The reference of the function set.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
-func Functions() Expr { return fn1("functions", NullV{}) }
-
-// ScopedFunctions creates a native ref for functions inside a database.
-//
-// Parameters:
-//  scope Ref - The reference of the function set's scope.
-//
-// Returns:
-//  Ref - The reference of the function set.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
-func ScopedFunctions(scope interface{}) Expr { return fn1("functions", scope) }
-
-// Roles creates a native ref for roles.
-//
-// Returns:
-//  Ref - The reference of the roles set.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
-func Roles() Expr { return fn1("roles", NullV{}) }
-
-// ScopedRole creates a native ref for roles inside a database.
-//
-// Parameters:
-//  scope Ref - The reference of the role set's scope.
-//
-// Returns:
-//  Ref - The reference of the role set.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
-func ScopedRoles(scope interface{}) Expr { return fn1("roles", scope) }
-
-// Keys creates a native ref for keys.
-//
-// Returns:
-//  Ref - The reference of the key set.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
-func Keys() Expr { return fn1("keys", NullV{}) }
-
-// ScopedKeys creates a native ref for keys inside a database.
-//
-// Parameters:
-//  scope Ref - The reference of the key set's scope.
-//
-// Returns:
-//  Ref - The reference of the key set.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
-func ScopedKeys(scope interface{}) Expr { return fn1("keys", scope) }
-
-// Tokens creates a native ref for tokens.
-//
-// Returns:
-//  Ref - The reference of the token set.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
-func Tokens() Expr { return fn1("tokens", NullV{}) }
-
-// ScopedTokens creates a native ref for tokens inside a database.
-//
-// Parameters:
-//  scope Ref - The reference of the token set's scope.
-//
-// Returns:
-//  Ref - The reference of the token set.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
-func ScopedTokens(scope interface{}) Expr { return fn1("tokens", scope) }
-
-// Credentials creates a native ref for credentials.
-//
-// Returns:
-//  Ref - The reference of the credential set.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
-func Credentials() Expr { return fn1("credentials", NullV{}) }
-
-// ScopedCredentials creates a native ref for credentials inside a database.
-//
-// Parameters:
-//  scope Ref - The reference of the credential set's scope.
-//
-// Returns:
-//  Ref - The reference of the credential set.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
-func ScopedCredentials(scope interface{}) Expr { return fn1("credentials", scope) }
-
-// Equals checks if all args are equivalents.
-//
-// Parameters:
-//  args []Value - A collection of expressions to check for equivalence.
-//
-// Returns:
-//  bool - true if all elements are equals, false otherwise.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
-func Equals(args ...interface{}) Expr { return fn1("equals", varargs(args...)) }
-
-// Contains checks if the provided value contains the path specified.
-//
-// Parameters:
-//  path Path - An array representing a path to check for the existence of. Path can be either strings or ints.
-//  value Object - An object to search against.
-//
-// Returns:
-//  bool - true if the path contains any value, false otherwise.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
-func Contains(path, value interface{}) Expr { return fn2("contains", path, "in", value) }
-
-// Abs computes the absolute value of a number.
-//
-// Parameters:
-//  value number - The number to take the absolute value of
-//
-// Returns:
-//  number - The abosulte value of a number
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
-func Abs(value interface{}) Expr { return fn1("abs", value) }
-
-// Acos computes the arccosine of a number.
-//
-// Parameters:
-//  value number - The number to take the arccosine of
-//
-// Returns:
-//  number - The arccosine of a number
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
-func Acos(value interface{}) Expr { return fn1("acos", value) }
-
-// Asin computes the arcsine of a number.
-//
-// Parameters:
-//  value number - The number to take the arcsine of
-//
-// Returns:
-//  number - The arcsine of a number
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
-func Asin(value interface{}) Expr { return fn1("asin", value) }
-
-// Atan computes the arctan of a number.
-//
-// Parameters:
-//  value number - The number to take the arctan of
-//
-// Returns:
-//  number - The arctan of a number
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
-func Atan(value interface{}) Expr { return fn1("atan", value) }
-
-// Add computes the sum of a list of numbers.
-//
-// Parameters:
-//  args []number - A collection of numbers to sum together.
-//
-// Returns:
-//  number - The sum of all elements.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
-func Add(args ...interface{}) Expr { return fn1("add", varargs(args...)) }
-
-// BitAnd computes the and of a list of numbers.
-//
-// Parameters:
-//  args []number - A collection of numbers to and together.
-//
-// Returns:
-//  number - The and of all elements.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
-func BitAnd(args ...interface{}) Expr { return fn1("bitand", varargs(args...)) }
-
-// BitNot computes the 2's complement of a number
-//
-// Parameters:
-//  value number - A numbers to not
-//
-// Returns:
-//  number - The not of an element
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
-func BitNot(value interface{}) Expr { return fn1("bitnot", value) }
-
-// BitOr computes the OR of a list of numbers.
-//
-// Parameters:
-//  args []number - A collection of numbers to OR together.
-//
-// Returns:
-//  number - The OR of all elements.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
-func BitOr(args ...interface{}) Expr { return fn1("bitor", varargs(args...)) }
-
-// BitXor computes the XOR of a list of numbers.
-//
-// Parameters:
-//  args []number - A collection of numbers to XOR together.
-//
-// Returns:
-//  number - The XOR of all elements.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
-func BitXor(args ...interface{}) Expr { return fn1("bitxor", varargs(args...)) }
-
-// Ceil computes the largest integer greater than or equal to
-//
-// Parameters:
-//  value number - A numbers to compute the ceil of
-//
-// Returns:
-//  number - The ceil of value
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
-func Ceil(value interface{}) Expr { return fn1("ceil", value) }
-
-// Cos computes the Cosine of a number
-//
-// Parameters:
-//  value number - A number to compute the cosine of
-//
-// Returns:
-//  number - The cosine of value
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
-func Cos(value interface{}) Expr { return fn1("cos", value) }
-
-// Cosh computes the Hyperbolic Cosine of a number
-//
-// Parameters:
-//  value number - A number to compute the Hyperbolic cosine of
-//
-// Returns:
-//  number - The Hyperbolic cosine of value
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
-func Cosh(value interface{}) Expr { return fn1("cosh", value) }
-
-// Degrees computes the degress of a number
-//
-// Parameters:
-//  value number - A number to compute the degress of
-//
-// Returns:
-//  number - The degrees of value
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
-func Degrees(value interface{}) Expr { return fn1("degrees", value) }
-
-// Divide computes the quotient of a list of numbers.
-//
-// Parameters:
-//  args []number - A collection of numbers to compute the quotient of.
-//
-// Returns:
-//  number - The quotient of all elements.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
-func Divide(args ...interface{}) Expr { return fn1("divide", varargs(args...)) }
-
-// Exp computes the Exp of a number
-//
-// Parameters:
-//  value number - A number to compute the exp of
-//
-// Returns:
-//  number - The exp of value
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
-func Exp(value interface{}) Expr { return fn1("exp", value) }
-
-// Floor computes the Floor of a number
-//
-// Parameters:
-//  value number - A number to compute the Floor of
-//
-// Returns:
-//  number - The Floor of value
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
-func Floor(value interface{}) Expr { return fn1("floor", value) }
-
-// Hypot computes the Hypotenuse of two numbers
-//
-// Parameters:
-//  a number - A side of a right triangle
-//  b number - A side of a right triangle
-//
-// Returns:
-//  number - The hypotenuse of value
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
-func Hypot(a, b interface{}) Expr { return fn2("hypot", a, "b", b) }
-
-// Ln computes the natural log of a number
-//
-// Parameters:
-//  value number - A number to compute the natural log of
-//
-// Returns:
-//  number - The ln of value
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
-func Ln(value interface{}) Expr { return fn1("ln", value) }
-
-// Log computes the Log of a number
-//
-// Parameters:
-//  value number - A number to compute the Log of
-//
-// Returns:
-//  number - The Log of value
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
-func Log(value interface{}) Expr { return fn1("log", value) }
-
-// Max computes the max of a list of numbers.
-//
-// Parameters:
-//  args []number - A collection of numbers to find the max of.
-//
-// Returns:
-//  number - The max of all elements.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
-func Max(args ...interface{}) Expr { return fn1("max", varargs(args...)) }
-
-// Min computes the Min of a list of numbers.
-//
-// Parameters:
-//  args []number - A collection of numbers to find the min of.
-//
-// Returns:
-//  number - The min of all elements.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
-func Min(args ...interface{}) Expr { return fn1("min", varargs(args...)) }
-
-// Modulo computes the reminder after the division of a list of numbers.
-//
-// Parameters:
-//  args []number - A collection of numbers to compute the quotient of. The remainder will be returned.
-//
-// Returns:
-//  number - The remainder of the quotient of all elements.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
-func Modulo(args ...interface{}) Expr { return fn1("modulo", varargs(args...)) }
-
-// Multiply computes the product of a list of numbers.
-//
-// Parameters:
-//  args []number - A collection of numbers to multiply together.
-//
-// Returns:
-//  number - The multiplication of all elements.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
-func Multiply(args ...interface{}) Expr { return fn1("multiply", varargs(args...)) }
-
-// Pow computes the Power of a number
-//
-// Parameters:
-//  base number - A number which is the base
-//  exp number  - A number which is the exponent
-//
-// Returns:
-//  number - The Pow of value
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
-func Pow(base, exp interface{}) Expr { return fn2("pow", base, "exp", exp) }
-
-// Radians computes the Radians of a number
-//
-// Parameters:
-//  value number - A number which is convert to radians
-//
-// Returns:
-//  number - The Radians of value
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
-func Radians(value interface{}) Expr { return fn1("radians", value) }
-
-// Round a number at the given percission
-//
-// Parameters:
-//  value number - The number to truncate
-//  precision number - precision where to truncate, defaults is 2
-//
-// Returns:
-//  number - The Rounded value.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
-func Round(value interface{}, options ...OptionalParameter) Expr {
-	return fn1("round", value, options...)
-}
-
-// Sign computes the Sign of a number
-//
-// Parameters:
-//  value number - A number to compute the Sign of
-//
-// Returns:
-//  number - The Sign of value
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
-func Sign(value interface{}) Expr { return fn1("sign", value) }
-
-// Sin computes the Sine of a number
-//
-// Parameters:
-//  value number - A number to compute the Sine of
-//
-// Returns:
-//  number - The Sine of value
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
-func Sin(value interface{}) Expr { return fn1("sin", value) }
-
-// Sinh computes the Hyperbolic Sine of a number
-//
-// Parameters:
-//  value number - A number to compute the Hyperbolic Sine of
-//
-// Returns:
-//  number - The Hyperbolic Sine of value
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
-func Sinh(value interface{}) Expr { return fn1("sinh", value) }
-
-// Sqrt computes the square root of a number
-//
-// Parameters:
-//  value number - A number to compute the square root of
-//
-// Returns:
-//  number - The square root of value
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
-func Sqrt(value interface{}) Expr { return fn1("sqrt", value) }
-
-// Subtract computes the difference of a list of numbers.
-//
-// Parameters:
-//  args []number - A collection of numbers to compute the difference of.
-//
-// Returns:
-//  number - The difference of all elements.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
-func Subtract(args ...interface{}) Expr { return fn1("subtract", varargs(args...)) }
-
-// Tan computes the Tangent of a number
-//
-// Parameters:
-//  value number - A number to compute the Tangent of
-//
-// Returns:
-//  number - The Tangent of value
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
-func Tan(value interface{}) Expr { return fn1("tan", value) }
-
-// Tanh computes the Hyperbolic Tangent of a number
-//
-// Parameters:
-//  value number - A number to compute the Hyperbolic Tangent of
-//
-// Returns:
-//  number - The Hyperbolic Tangent of value
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
-func Tanh(value interface{}) Expr { return fn1("tanh", value) }
-
-// Trunc truncates a number at the given percission
-//
-// Parameters:
-//  value number - The number to truncate
-//  precision number - precision where to truncate, defaults is 2
-//
-// Returns:
-//  number - The truncated value.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#mathematical-functions
-func Trunc(value interface{}, options ...OptionalParameter) Expr {
-	return fn1("trunc", value, options...)
-}
-
-// Any evaluates to true if any element of the collection is true.
-//
-// Parameters:
-// collection  - the collection
-//
-// Returns:
-// Expr
-//
-// See: https://docs.fauna.com/fauna/current/api/fql/functions/any
-func Any(collection interface{}) Expr {
-	return fn1("any", collection)
-}
-
-// All evaluates to true if all elements of the collection are true.
-//
-// Parameters:
-// collection - the collection
-//
-// Returns:
-// Expr
-//
-// See: https://docs.fauna.com/fauna/current/api/fql/functions/all
-func All(collection interface{}) Expr {
-	return fn1("all", collection)
-}
-
-// Count returns the number of elements in the collection.
-//
-// Parameters:
-// collection Expr - the collection
-//
-// Returns:
-// a new Expr instance
-//
-// See: https://docs.fauna.com/fauna/current/api/fql/functions/count
-func Count(collection interface{}) Expr {
-	return fn1("count", collection)
-}
-
-// Sum sums the elements in the collection.
-//
-// Parameters:
-// collection Expr - the collection
-//
-// Returns:
-// a new Expr instance
-//
-// See: https://docs.fauna.com/fauna/current/api/fql/functions/sum
-func Sum(collection interface{}) Expr {
-	return fn1("sum", collection)
-}
-
-// Mean returns the mean of all elements in the collection.
-//
-// Parameters:
-//
-// collection Expr - the collection
-//
-// Returns:
-// a new Expr instance
-//
-// See: https://docs.fauna.com/fauna/current/api/fql/functions/mean
-func Mean(collection interface{}) Expr {
-	return fn1("mean", collection)
-}
-
-// LT returns true if each specified value is less than all the subsequent values. Otherwise LT returns false.
-//
-// Parameters:
-//  args []number - A collection of terms to compare.
-//
-// Returns:
-//  bool - true if all elements are less than each other from left to right.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
-func LT(args ...interface{}) Expr { return fn1("lt", varargs(args...)) }
-
-// LTE returns true if each specified value is less than or equal to all subsequent values. Otherwise LTE returns false.
-//
-// Parameters:
-//  args []number - A collection of terms to compare.
-//
-// Returns:
-//  bool - true if all elements are less than of equals each other from left to right.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
-func LTE(args ...interface{}) Expr { return fn1("lte", varargs(args...)) }
-
-// GT returns true if each specified value is greater than all subsequent values. Otherwise GT returns false.
-// and false otherwise.
-//
-// Parameters:
-//  args []number - A collection of terms to compare.
-//
-// Returns:
-//  bool - true if all elements are greather than to each other from left to right.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
-func GT(args ...interface{}) Expr { return fn1("gt", varargs(args...)) }
-
-// GTE returns true if each specified value is greater than or equal to all subsequent values. Otherwise GTE returns false.
-//
-// Parameters:
-//  args []number - A collection of terms to compare.
-//
-// Returns:
-//  bool - true if all elements are greather than or equals to each other from left to right.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
-func GTE(args ...interface{}) Expr { return fn1("gte", varargs(args...)) }
-
-// And returns the conjunction of a list of boolean values.
-//
-// Parameters:
-//  args []bool - A collection to compute the conjunction of.
-//
-// Returns:
-//  bool - true if all elements are true, false otherwise.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
-func And(args ...interface{}) Expr { return fn1("and", varargs(args...)) }
-
-// Or returns the disjunction of a list of boolean values.
-//
-// Parameters:
-//  args []bool - A collection to compute the disjunction of.
-//
-// Returns:
-//  bool - true if at least one element is true, false otherwise.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
-func Or(args ...interface{}) Expr { return fn1("or", varargs(args...)) }
-
-// Not returns the negation of a boolean value.
-//
-// Parameters:
-//  boolean bool - A boolean to produce the negation of.
-//
-// Returns:
-//  bool - The value negated.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#miscellaneous-functions
-func Not(boolean interface{}) Expr { return fn1("not", boolean) }
-
-// Select traverses into the provided value, returning the value at the given path.
-//
-// Parameters:
-//  path []Path - An array representing a path to pull from an object. Path can be either strings or numbers.
-//  value Object - The object to select from.
-//
-// Optional parameters:
-//  default Value - A default value if the path does not exist. See Default() function.
-//
-// Returns:
-//  Value - The value at the given path location.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#read-functions
-func Select(path, value interface{}, options ...OptionalParameter) Expr {
-	return fn2("select", path, "from", value, options...)
-}
-
-// SelectAll traverses into the provided value flattening all values under the desired path.
-//
-// Parameters:
-//  path []Path - An array representing a path to pull from an object. Path can be either strings or numbers.
-//  value Object - The object to select from.
-//
-// Returns:
-//  Value - The value at the given path location.
-//
-// See: https://app.fauna.com/documentation/reference/queryapi#read-functions
-func SelectAll(path, value interface{}) Expr {
-	return fn2("select_all", path, "from", value)
-}
-
-// ToString attempts to convert an expression to a string literal.
-//
-// Parameters:
-//   value Object - The expression to convert.
-//
-// Returns:
-//   string - A string literal.
-func ToString(value interface{}) Expr {
-	return fn1("to_string", value)
-}
-
-// ToNumber attempts to convert an expression to a numeric literal -
-// either an int64 or float64.
-//
-// Parameters:
-//   value Object - The expression to convert.
-//
-// Returns:
-//   number - A numeric literal.
-func ToNumber(value interface{}) Expr {
-	return fn1("to_number", value)
-}
-
-// ToTime attempts to convert an expression to a time literal.
-//
-// Parameters:
-//    value Object - The expression to convert.
-//
-// Returns:
-//   time - A time literal.
-func ToTime(value interface{}) Expr {
-	return fn1("to_time", value)
-}
-
-// Converts a time expression to seconds since the UNIX epoch.
-//
-// Parameters:
-//    value Object - The expression to convert.
-//
-// Returns:
-//   time - A time literal.
-func ToSeconds(value interface{}) Expr {
-	return fn1("to_seconds", value)
-}
-
-// Converts a time expression to milliseconds since the UNIX epoch.
-//
-// Parameters:
-//    value Object - The expression to convert.
-//
-// Returns:
-//   time - A time literal.
-func ToMillis(value interface{}) Expr {
-	return fn1("to_millis", value)
-}
-
-// Converts a time expression to microseconds since the UNIX epoch.
-//
-// Parameters:
-//    value Object - The expression to convert.
-//
-// Returns:
-//   time - A time literal.
-func ToMicros(value interface{}) Expr {
-	return fn1("to_micros", value)
-}
-
-// Returns the time expression's year, following the ISO-8601 standard.
-//
-// Parameters:
-//    value Object - The expression to convert.
-//
-// Returns:
-//   time - year.
-func Year(value interface{}) Expr {
-	return fn1("year", value)
-}
-
-// Returns a time expression's month of the year, from 1 to 12.
-//
-// Parameters:
-//    value Object - The expression to convert.
-//
-// Returns:
-//   time - Month.
-func Month(value interface{}) Expr {
-	return fn1("month", value)
-}
-
-// Returns a time expression's hour of the day, from 0 to 23.
-//
-// Parameters:
-//    value Object - The expression to convert.
-//
-// Returns:
-//   time - year.
-func Hour(value interface{}) Expr {
-	return fn1("hour", value)
-}
-
-// Returns a time expression's minute of the hour, from 0 to 59.
-//
-// Parameters:
-//    value Object - The expression to convert.
-//
-// Returns:
-//   time - year.
-func Minute(value interface{}) Expr {
-	return fn1("minute", value)
-}
-
-// Returns a time expression's second of the minute, from 0 to 59.
-//
-// Parameters:
-//    value Object - The expression to convert.
-//
-// Returns:
-//   time - year.
-func Second(value interface{}) Expr {
-	return fn1("second", value)
-}
-
-// Returns a time expression's day of the month, from 1 to 31.
-//
-// Parameters:
-//    value Object - The expression to convert.
-//
-// Returns:
-//   time - day of month.
-func DayOfMonth(value interface{}) Expr {
-	return fn1("day_of_month", value)
-}
-
-// Returns a time expression's day of the week following ISO-8601 convention, from 1 (Monday) to 7 (Sunday).
-//
-// Parameters:
-//    value Object - The expression to convert.
-//
-// Returns:
-//   time - day of week.
-func DayOfWeek(value interface{}) Expr {
-	return fn1("day_of_week", value)
-}
-
-// Returns a time expression's day of the year, from 1 to 365, or 366 in a leap year.
-//
-// Parameters:
-//    value Object - The expression to convert.
-//
-// Returns:
-//   time - Day of the year.
-func DayOfYear(value interface{}) Expr {
-	return fn1("day_of_year", value)
-}
-
-// ToDate attempts to convert an expression to a date literal.
-//
-// Parameters:
-//    value Object - The expression to convert.
-//
-// Returns:
-//   date - A date literal.
-func ToDate(value interface{}) Expr {
-	return fn1("to_date", value)
-}
-
-// IsNumber checks if the expression is a number
-//
-// Parameters:
-//  expr Expr - The expression to check.
-//
-// Returns:
-//  bool      -  returns true if the expression is a number
-func IsNumber(expr interface{}) Expr {
-	return fn1("is_number", expr)
-}
-
-// IsDouble checks if the expression is a double
-//
-// Parameters:
-//  expr Expr - The expression to check.
-//
-// Returns:
-//  bool         -  returns true if the expression is a double
-func IsDouble(expr interface{}) Expr {
-	return fn1("is_double", expr)
-}
-
-// IsInteger checks if the expression is an integer
-//
-// Parameters:
-//  expr Expr - The expression to check.
-//
-// Returns:
-//  bool         -  returns true if the expression is an integer
-func IsInteger(expr interface{}) Expr {
-	return fn1("is_integer", expr)
-}
-
-// IsBoolean checks if the expression is a boolean
-//
-// Parameters:
-//  expr Expr - The expression to check.
-//
-// Returns:
-//  bool         -  returns true if the expression is a boolean
-func IsBoolean(expr interface{}) Expr {
-	return fn1("is_boolean", expr)
-}
-
-// IsNull checks if the expression is null
-//
-// Parameters:
-//  expr Expr - The expression to check.
-//
-// Returns:
-//  bool         -  returns true if the expression is null
-func IsNull(expr interface{}) Expr {
-	return fn1("is_null", expr)
-}
-
-// IsBytes checks if the expression are bytes
-//
-// Parameters:
-//  expr Expr - The expression to check.
-//
-// Returns:
-//  bool         -  returns true if the expression are bytes
-func IsBytes(expr interface{}) Expr {
-	return fn1("is_bytes", expr)
-}
-
-// IsTimestamp checks if the expression is a timestamp
-//
-// Parameters:
-//  expr Expr - The expression to check.
-//
-// Returns:
-//  bool         -  returns true if the expression is a timestamp
-func IsTimestamp(expr interface{}) Expr {
-	return fn1("is_timestamp", expr)
-}
-
-// IsDate checks if the expression is a date
-//
-// Parameters:
-//  expr Expr - The expression to check.
-//
-// Returns:
-//  bool         -  returns true if the expression is a date
-func IsDate(expr interface{}) Expr {
-	return fn1("is_date", expr)
-}
-
-// IsString checks if the expression is a string
-//
-// Parameters:
-//  expr Expr - The expression to check.
-//
-// Returns:
-//  bool         -  returns true if the expression is a string
-func IsString(expr interface{}) Expr {
-	return fn1("is_string", expr)
-}
-
-// IsArray checks if the expression is an array
-//
-// Parameters:
-//  expr Expr - The expression to check.
-//
-// Returns:
-//  bool         -  returns true if the expression is an array
-func IsArray(expr interface{}) Expr {
-	return fn1("is_array", expr)
-}
-
-// IsObject checks if the expression is an object
-//
-// Parameters:
-//  expr Expr - The expression to check.
-//
-// Returns:
-//  bool         -  returns true if the expression is an object
-func IsObject(expr interface{}) Expr {
-	return fn1("is_object", expr)
-}
-
-// IsRef checks if the expression is a ref
-//
-// Parameters:
-//  expr Expr - The expression to check.
-//
-// Returns:
-//  bool         -  returns true if the expression is a ref
-func IsRef(expr interface{}) Expr {
-	return fn1("is_ref", expr)
-}
-
-// IsSet checks if the expression is a set
-//
-// Parameters:
-//  expr Expr - The expression to check.
-//
-// Returns:
-//  bool         -  returns true if the expression is a set
-func IsSet(expr interface{}) Expr {
-	return fn1("is_set", expr)
-}
-
-// IsDoc checks if the expression is a document
-//
-// Parameters:
-//  expr Expr - The expression to check.
-//
-// Returns:
-//  bool         -  returns true if the expression is a document
-func IsDoc(expr interface{}) Expr {
-	return fn1("is_doc", expr)
-}
-
-// IsLambda checks if the expression is a Lambda
-//
-// Parameters:
-//  expr Expr - The expression to check.
-//
-// Returns:
-//  bool         -  returns true if the expression is a Lambda
-func IsLambda(expr interface{}) Expr {
-	return fn1("is_lambda", expr)
-}
-
-// IsCollection checks if the expression is a collection
-//
-// Parameters:
-//  expr Expr - The expression to check.
-//
-// Returns:
-//  bool         -  returns true if the expression is a collection
-func IsCollection(expr interface{}) Expr {
-	return fn1("is_collection", expr)
-}
-
-// IsDatabase checks if the expression is a database
-//
-// Parameters:
-//  expr Expr - The expression to check.
-//
-// Returns:
-//  bool         -  returns true if the expression is a database
-func IsDatabase(expr interface{}) Expr {
-	return fn1("is_database", expr)
-}
-
-// IsIndex checks if the expression is an index
-//
-// Parameters:
-//  expr Expr - The expression to check.
-//
-// Returns:
-//  bool         -  returns true if the expression is an index
-func IsIndex(expr interface{}) Expr {
-	return fn1("is_index", expr)
-}
-
-// IsFunction checks if the expression is a function
-//
-// Parameters:
-//  expr Expr - The expression to check.
-//
-// Returns:
-//  bool         -  returns true if the expression is a function
-func IsFunction(expr interface{}) Expr {
-	return fn1("is_function", expr)
-}
-
-// IsKey checks if the expression is a key
-//
-// Parameters:
-//  expr Expr - The expression to check.
-//
-// Returns:
-//  bool         -  returns true if the expression is a key
-func IsKey(expr interface{}) Expr {
-	return fn1("is_key", expr)
-}
-
-// IsToken checks if the expression is a token
-//
-// Parameters:
-//  expr Expr - The expression to check.
-//
-// Returns:
-//  bool         -  returns true if the expression is a token
-func IsToken(expr interface{}) Expr {
-	return fn1("is_token", expr)
-}
-
-// IsCredentials checks if the expression is a credentials
-//
-// Parameters:
-//  expr Expr - The expression to check.
-//
-// Returns:
-//  bool         -  returns true if the expression is a credential
-func IsCredentials(expr interface{}) Expr {
-	return fn1("is_credentials", expr)
-}
-
-// IsRole checks if the expression is a role
-//
-// Parameters:
-//  expr Expr - The expression to check.
-//
-// Returns:
-//  bool         -  returns true if the expression is a role
-func IsRole(expr interface{}) Expr {
-	return fn1("is_role", expr)
+func (fn casefoldFn) setNormalizer(e Expr) Expr {
+	fn.Normalizer = e
+	return fn
 }

--- a/faunadb/serialization_test.go
+++ b/faunadb/serialization_test.go
@@ -1686,7 +1686,7 @@ func assertJSON(t *testing.T, expr Expr, expected string) {
 	bytes, err := json.Marshal(expr)
 
 	require.NoError(t, err)
-	require.Equal(t, expected, string(bytes))
+	require.JSONEq(t, expected, string(bytes))
 }
 
 func assertMarshal(t *testing.T, value Value, expected string) {

--- a/faunadb/strconv.go
+++ b/faunadb/strconv.go
@@ -1,0 +1,107 @@
+package faunadb
+
+import (
+	"reflect"
+	"strings"
+)
+
+func printFn(fn interface{}) string {
+
+	t := reflect.TypeOf(fn)
+	if t.Kind() != reflect.Struct {
+		return "fnApply should only be of type struct"
+	}
+
+	var name string
+	var sbOpt strings.Builder
+	var sbArgs strings.Builder
+	val := reflect.ValueOf(fn)
+
+	for idx := 0; idx < t.NumField(); idx++ {
+		field := t.Field(idx)
+		if field.Name == "fnApply" {
+			continue
+		}
+		if idx == 1 {
+			name = field.Name
+		}
+
+		fv := val.Field(idx)
+		var v Expr
+		if fv.IsNil() {
+			v = NullV{}
+		} else {
+			v = wrap(fv.Interface())
+		}
+
+		reprVals := map[string]string{}
+		if tag, b := field.Tag.Lookup("faunarepr"); b {
+			tagVals := strings.Split(tag, ",")
+			for _, key := range tagVals {
+				pair := strings.Split(key, "=")
+				switch len(pair) {
+				case 1:
+					reprVals["fn"] = pair[0]
+				case 2:
+					reprVals[pair[0]] = pair[1]
+				}
+			}
+
+			switch reprVals["fn"] {
+			case "scopedfn":
+				if (v != NullV{}) {
+					name = "Scoped" + name
+					if sbArgs.Len() > 0 {
+						sbArgs.WriteString(", ")
+					}
+					sbArgs.WriteString(v.String())
+				}
+			case "optfn":
+				if (v != NullV{}) {
+					optFnName := field.Name
+					if len(reprVals["name"]) != 0 {
+						optFnName = reprVals["name"]
+					}
+					if sbOpt.Len()+sbArgs.Len() > 0 {
+						sbOpt.WriteString(", ")
+					}
+					sbOpt.WriteString(optFnName)
+					sbOpt.WriteString("(")
+					if _, ok := reprVals["noargs"]; !ok {
+						sbOpt.WriteString(v.String())
+					}
+					sbOpt.WriteString(")")
+				}
+
+			case "varargs":
+				if reflect.TypeOf(v).ConvertibleTo(reflect.TypeOf(unescapedArr{})) {
+					nestedArgs := reflect.ValueOf(v).Interface().(unescapedArr)
+					for _, nv := range nestedArgs {
+						if sbArgs.Len() > 0 {
+							sbArgs.WriteString(", ")
+						}
+						sbArgs.WriteString(nv.String())
+					}
+				} else {
+					if sbArgs.Len()+sbOpt.Len() > 0 {
+						sbArgs.WriteString(", ")
+					}
+					sbArgs.WriteString(v.String())
+				}
+			case "noargs":
+
+			default:
+				return "Unknown faunarepr: `" + reprVals["fn"] + "` in " + name
+			}
+		} else {
+			if tag, b := field.Tag.Lookup("json"); b && strings.HasSuffix(tag, ",omitempty") {
+				continue
+			}
+			if sbArgs.Len()+sbOpt.Len() > 0 {
+				sbArgs.WriteString(", ")
+			}
+			sbArgs.WriteString(v.String())
+		}
+	}
+	return name + "(" + sbArgs.String() + sbOpt.String() + ")"
+}

--- a/faunadb/strconv_test.go
+++ b/faunadb/strconv_test.go
@@ -1,0 +1,332 @@
+package faunadb
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func assertString(t *testing.T, expr Expr, expected string) {
+	str := expr.String()
+	require.Equal(t, expected, str)
+}
+
+func TestStringifyFaunaValues(t *testing.T) {
+	assertString(t, StringV("a string"), `"a string"`)
+	assertString(t, LongV(90), `90`)
+
+	arr := Arr{
+		LongV(1), LongV(2), LongV(3),
+		NullV{}, Obj{"a": "bcde"},
+		BooleanV(true), BooleanV(false),
+	}
+	assertString(t,
+		arr,
+		`Arr{1, 2, 3, nil, Obj{"a": "bcde"}, true, false}`,
+	)
+
+	assertString(t,
+		NullV{},
+		`nil`,
+	)
+
+	assertString(t,
+		SetRefV{Parameters: map[string]Value{"x": StringV("y")}},
+		`SetRefV{ Parameters: map[string]Value{"x": "y"} }`,
+	)
+
+	assertString(t,
+		nativeCollections,
+		`RefV{ID: "collections"}`,
+	)
+
+	assertString(t,
+		RefV{Database: &RefV{ID: "db1"}},
+		`RefV{Database: &RefV{ID: "db1"}}`,
+	)
+
+	now := time.Now()
+	assertString(t,
+		TimeV(now),
+		`TimeV("`+now.Format("2006-01-02T15:04:05.999999999Z")+`")`,
+	)
+
+}
+
+func TestStringifyFixedArityFunctions(t *testing.T) {
+
+	assertString(t, Add(1, 2, 3), `Add(1, 2, 3)`)
+
+	assertString(t, Append(Arr{3, 4}, Arr{1, 2}), `Append(Arr{3, 4}, Arr{1, 2})`)
+	assertString(t, Exists(Function("a_function")), `Exists(Function("a_function"))`)
+	assertString(t, DayOfMonth(Epoch(0, "second")), `DayOfMonth(Epoch(0, "second"))`)
+	assertString(t, DayOfMonth(Epoch(2147483648, "second")), `DayOfMonth(Epoch(2147483648, "second"))`)
+	assertString(t, DayOfMonth(0), `DayOfMonth(0)`)
+	assertString(t, DayOfMonth(2147483648000000), `DayOfMonth(2147483648000000)`)
+	assertString(t, DayOfWeek(Epoch(0, "second")), `DayOfWeek(Epoch(0, "second"))`)
+	assertString(t, DayOfWeek(Epoch(2147483648, "second")), `DayOfWeek(Epoch(2147483648, "second"))`)
+	assertString(t, DayOfWeek(0), `DayOfWeek(0)`)
+	assertString(t, DayOfWeek(2147483648000000), `DayOfWeek(2147483648000000)`)
+	assertString(t, DayOfYear(Epoch(0, "second")), `DayOfYear(Epoch(0, "second"))`)
+	assertString(t, DayOfYear(Epoch(2147483648, "second")), `DayOfYear(Epoch(2147483648, "second"))`)
+	assertString(t, DayOfYear(0), `DayOfYear(0)`)
+	assertString(t, DayOfYear(2147483648000000), `DayOfYear(2147483648000000)`)
+
+	assertString(t, Drop(2, Arr{1, 2, 3}), `Drop(2, Arr{1, 2, 3})`)
+	assertString(t, Query(Lambda("x", Var("x"))), `Query(Lambda("x", Var("x")))`)
+	assertString(t, Abs(-2), `Abs(-2)`)
+	assertString(t, Acos(1), `Acos(1)`)
+	assertString(t, Add(Arr{2, 3}), `Add(2, 3)`)
+	assertString(t, And(Arr{true, true}), `And(true, true)`)
+	assertString(t, Arr{Any(Arr{true, true, false}), All(Arr{true, true, true}), Any(Arr{false, false, false}), All(Arr{true, true, false})}, `Arr{Any(Arr{true, true, false}), All(Arr{true, true, true}), Any(Arr{false, false, false}), All(Arr{true, true, false})}`)
+	assertString(t, Trunc(Asin(5e-01)), `Trunc(Asin(5E-01))`)
+	assertString(t, Trunc(Atan(5e-01)), `Trunc(Atan(5E-01))`)
+	assertString(t, BitAnd(Arr{2, 3}), `BitAnd(2, 3)`)
+	assertString(t, BitNot(2), `BitNot(2)`)
+	assertString(t, BitOr(Arr{2, 1}), `BitOr(2, 1)`)
+	assertString(t, BitXor(Arr{2, 3}), `BitXor(2, 3)`)
+	assertString(t, Casefold("GET DOWN"), `Casefold("GET DOWN")`)
+
+	assertString(t, Ceil(1.8e+00), `Ceil(1.8E+00)`)
+	assertString(t, Concat(Arr{"Hello", "World"}), `Concat(Arr{"Hello", "World"})`)
+	assertString(t, ContainsStr("faunadb", "fauna"), `ContainsStr("faunadb", "fauna")`)
+	assertString(t, ContainsStrRegex("faunadb", "f(\\w+)a"), `ContainsStrRegex("faunadb", "f(\\w+)a")`)
+	assertString(t, ContainsStrRegex("faunadb", "/^\\d*\\.\\d+$/"), `ContainsStrRegex("faunadb", "/^\\d*\\.\\d+$/")`)
+	assertString(t, ContainsStrRegex("test data", "\\s"), `ContainsStrRegex("test data", "\\s")`)
+	assertString(t, Trunc(Cosh(5e-01)), `Trunc(Cosh(5E-01))`)
+	assertString(t, Arr{Count(Arr{1, 2, 3, 4, 5, 6, 7, 8, 9}), Mean(Arr{1, 2, 3, 4, 5, 6, 7, 8, 9}), Sum(Arr{1, 2, 3, 4, 5, 6, 7, 8, 9})}, `Arr{Count(Arr{1, 2, 3, 4, 5, 6, 7, 8, 9}), Mean(Arr{1, 2, 3, 4, 5, 6, 7, 8, 9}), Sum(Arr{1, 2, 3, 4, 5, 6, 7, 8, 9})}`)
+	assertString(t, Arr{Count(Match(Index("countmeansum_idx"))), Trunc(Mean(Match(Index("countmeansum_idx")))), Sum(Match(Index("countmeansum_idx")))}, `Arr{Count(Match(Index("countmeansum_idx"))), Trunc(Mean(Match(Index("countmeansum_idx")))), Sum(Match(Index("countmeansum_idx")))}`)
+	assertString(t, Date("1970-01-02"), `Date("1970-01-02")`)
+	assertString(t, Trunc(Degrees(5e-01)), `Trunc(Degrees(5E-01))`)
+	assertString(t, Divide(Arr{10, 2}), `Divide(10, 2)`)
+	assertString(t, Select(Arr{0}, Count(Paginate(Documents(Collection("collection_2276634055"))))), `Select(Arr{0}, Count(Paginate(Documents(Collection("collection_2276634055")))))`)
+	assertString(t, Count(Documents(Collection("collection_2276634055"))), `Count(Documents(Collection("collection_2276634055")))`)
+	assertString(t, EndsWith("faunadb", "fauna"), `EndsWith("faunadb", "fauna")`)
+	assertString(t, EndsWith("faunadb", "db"), `EndsWith("faunadb", "db")`)
+	assertString(t, EndsWith("faunadb", ""), `EndsWith("faunadb", "")`)
+	assertString(t, Arr{Epoch(30, "second"), Epoch(30, "millisecond"), Epoch(30, "microsecond"), Epoch(30, "nanosecond")}, `Arr{Epoch(30, "second"), Epoch(30, "millisecond"), Epoch(30, "microsecond"), Epoch(30, "nanosecond")}`)
+	assertString(t, Equals(Arr{"fire", "fire"}), `Equals("fire", "fire")`)
+	assertString(t, Trunc(Exp(2)), `Trunc(Exp(2))`)
+	assertString(t, FindStr("GET DOWN", "DOWN"), `FindStr("GET DOWN", "DOWN")`)
+	assertString(t, Floor(2.99e+00), `Floor(2.99E+00)`)
+	assertString(t, Format("%2$s%1$s %3$s", Arr{"DB", "Fauna", "rocks"}), `Format("%2$s%1$s %3$s", Arr{"DB", "Fauna", "rocks"})`)
+	assertString(t, Format("%d %s %.2f %%", Arr{34, "tEsT ", 3.14159e+00}), `Format("%d %s %.2f %%", Arr{34, "tEsT ", 3.14159E+00})`)
+	assertString(t, GTE(Arr{2, 2}), `GTE(2, 2)`)
+	assertString(t, GT(Arr{3, 2}), `GT(3, 2)`)
+
+	assertString(t, If(true, "true", "false"), `If(true, "true", "false")`)
+	assertString(t, LTE(Arr{2, 2}), `LTE(2, 2)`)
+	assertString(t, LT(Arr{2, 3}), `LT(2, 3)`)
+	assertString(t, LTrim("    One Fish Two Fish"), `LTrim("    One Fish Two Fish")`)
+	assertString(t, Length("One Fish Two Fish"), `Length("One Fish Two Fish")`)
+
+	assertString(t, Trunc(Ln(2)), `Trunc(Ln(2))`)
+	assertString(t, Log(100), `Log(100)`)
+	assertString(t, LowerCase("One Fish Two Fish"), `Lowercase("One Fish Two Fish")`)
+	assertString(t, Max(Arr{2, 3}), `Max(2, 3)`)
+	assertString(t, Min(Arr{4, 3}), `Min(4, 3)`)
+	assertString(t, Modulo(Arr{10, 2}), `Modulo(10, 2)`)
+	assertString(t, Multiply(Arr{2, 3}), `Multiply(2, 3)`)
+	assertString(t, Not(false), `Not(false)`)
+	assertString(t, Or(Arr{false, true}), `Or(false, true)`)
+	assertString(t, RTrim("One Fish Two Fish   "), `RTrim("One Fish Two Fish   ")`)
+	assertString(t, Trunc(Radians(2)), `Trunc(Radians(2))`)
+	assertString(t, RegexEscape("f(\\w+)a"), `RegexEscape("f(\\w+)a")`)
+	assertString(t, ReplaceStr("One Fish Two Fish", "Fish", "Dog"), `ReplaceStr("One Fish Two Fish", "Fish", "Dog")`)
+	assertString(t, ReplaceStrRegex("One FIsh Two fish", "[Ff][Ii]sh", "Dog"), `ReplaceStrRegex("One FIsh Two fish", "[Ff][Ii]sh", "Dog")`)
+	assertString(t, Sign(-1), `Sign(-1)`)
+	assertString(t, Trunc(Sin(20)), `Trunc(Sin(20))`)
+	assertString(t, Trunc(Sinh(5e-01)), `Trunc(Sinh(5E-01))`)
+	assertString(t, Space(5), `Space(5)`)
+	assertString(t, Sqrt(16), `Sqrt(16)`)
+	assertString(t, StartsWith("faunadb", "fauna"), `StartsWith("faunadb", "fauna")`)
+	assertString(t, StartsWith("faunadb", "F"), `StartsWith("faunadb", "F")`)
+	assertString(t, SubString("ABCDEF", 3), `SubString("ABCDEF", 3)`)
+	assertString(t, SubString("ABCDEF", -2), `SubString("ABCDEF", -2)`)
+	assertString(t, Subtract(Arr{2, 3}), `Subtract(2, 3)`)
+	assertString(t, Trunc(Tan(20)), `Trunc(Tan(20))`)
+	assertString(t, Trunc(Tanh(5e-01)), `Trunc(Tanh(5E-01))`)
+	assertString(t, TimeAdd(Epoch(0, "second"), 1, "hour"), `TimeAdd(Epoch(0, "second"), 1, "hour")`)
+	assertString(t, TimeAdd(Epoch(0, "second"), 16, "minute"), `TimeAdd(Epoch(0, "second"), 16, "minute")`)
+	assertString(t, TimeDiff(Epoch(0, "second"), Epoch(1, "second"), "second"), `TimeDiff(Epoch(0, "second"), Epoch(1, "second"), "second")`)
+	assertString(t, TimeDiff(Epoch(24, "hour"), Epoch(1, "day"), "hour"), `TimeDiff(Epoch(24, "hour"), Epoch(1, "day"), "hour")`)
+	assertString(t, Time("1970-01-01T00:00:00-04:00"), `Time("1970-01-01T00:00:00-04:00")`)
+	assertString(t, TimeSubtract(Epoch(190, "hour"), 78, "minute"), `TimeSubtract(Epoch(190, "hour"), 78, "minute")`)
+	assertString(t, TimeSubtract(Epoch(16, "second"), 16, "second"), `TimeSubtract(Epoch(16, "second"), 16, "second")`)
+	assertString(t, TitleCase("onE Fish tWO FiSh"), `Titlecase("onE Fish tWO FiSh")`)
+	assertString(t, ToDate("1970-01-02"), `ToDate("1970-01-02")`)
+	assertString(t, ToNumber("42"), `ToNumber("42")`)
+	assertString(t, ToString(42), `ToString(42)`)
+	assertString(t, ToTime("1970-01-01T00:00:00-04:00"), `ToTime("1970-01-01T00:00:00-04:00")`)
+	assertString(t, Trim("   One Fish Two Fish   "), `Trim("   One Fish Two Fish   ")`)
+	assertString(t, Trunc(1.234567e+00), `Trunc(1.234567E+00)`)
+	assertString(t, UpperCase("One Fish Two Fish"), `UpperCase("One Fish Two Fish")`)
+	assertString(t, Hour(Epoch(0, "second")), `Hour(Epoch(0, "second"))`)
+	assertString(t, Hour(Epoch(2147483648, "second")), `Hour(Epoch(2147483648, "second"))`)
+	assertString(t, Hour(0), `Hour(0)`)
+	assertString(t, Hour(2147483648000000), `Hour(2147483648000000)`)
+	assertString(t, IsEmpty(Arr{}), `IsEmpty(Arr{})`)
+	assertString(t, IsEmpty(Arr{1}), `IsEmpty(Arr{1})`)
+	assertString(t, IsNonEmpty(Arr{}), `IsNonEmpty(Arr{})`)
+	assertString(t, IsNonEmpty(Arr{1, 2}), `IsNonEmpty(Arr{1, 2})`)
+
+	assertString(t, Minute(Epoch(0, "second")), `Minute(Epoch(0, "second"))`)
+	assertString(t, Minute(Epoch(2147483648, "second")), `Minute(Epoch(2147483648, "second"))`)
+	assertString(t, Minute(0), `Minute(0)`)
+	assertString(t, Minute(2147483648000000), `Minute(2147483648000000)`)
+	assertString(t, Month(Epoch(0, "second")), `Month(Epoch(0, "second"))`)
+	assertString(t, Month(Epoch(2147483648, "second")), `Month(Epoch(2147483648, "second"))`)
+	assertString(t, Month(0), `Month(0)`)
+	assertString(t, Month(2147483648000000), `Month(2147483648000000)`)
+	assertString(t, Exists(ScopedCollection("collection_1675362432", ScopedDatabase("child_3306182225", Database("parent_3146154786")))), `Exists(ScopedCollection("collection_1675362432", ScopedDatabase("child_3306182225", Database("parent_3146154786"))))`)
+	assertString(t, Prepend(Arr{1, 2}, Arr{3, 4}), `Prepend(Arr{1, 2}, Arr{3, 4})`)
+	assertString(t, Select("data", Paginate(Range(Match(Index("range_idx")), 3, 8))), `Select("data", Paginate(Range(Match(Index("range_idx")), 3, 8)))`)
+	assertString(t, Select("data", Paginate(Range(Match(Index("range_idx")), 17, 18))), `Select("data", Paginate(Range(Match(Index("range_idx")), 17, 18)))`)
+	assertString(t, Select("data", Paginate(Range(Match(Index("range_idx")), 19, 0))), `Select("data", Paginate(Range(Match(Index("range_idx")), 19, 0)))`)
+	assertString(t, Reduce(Lambda(Arr{"accum", "value"}, Add(Arr{Var("accum"), Var("value")})), 0, Arr{1, 2, 3, 4, 5, 6, 7, 8, 9}), `Reduce(Lambda(Arr{"accum", "value"}, Add(Var("accum"), Var("value"))), 0, Arr{1, 2, 3, 4, 5, 6, 7, 8, 9})`)
+	assertString(t, Reduce(Lambda(Arr{"accum", "value"}, Concat(Arr{Var("accum"), Var("value")})), "", Arr{"Fauna", "DB", " ", "rocks"}), `Reduce(Lambda(Arr{"accum", "value"}, Concat(Arr{Var("accum"), Var("value")})), "", Arr{"Fauna", "DB", " ", "rocks"})`)
+	assertString(t, Second(Epoch(0, "second")), `Second(Epoch(0, "second"))`)
+	assertString(t, Second(Epoch(2147483648, "second")), `Second(Epoch(2147483648, "second"))`)
+	assertString(t, Second(0), `Second(0)`)
+	assertString(t, Second(2147483648000000), `Second(2147483648000000)`)
+	assertString(t, Take(2, Arr{1, 2, 3}), `Take(2, Arr{1, 2, 3})`)
+	assertString(t, ToMillis(Epoch(0, "second")), `ToMillis(Epoch(0, "second"))`)
+	assertString(t, ToMillis(Epoch(2147483648000000, "microsecond")), `ToMillis(Epoch(2147483648000000, "microsecond"))`)
+	assertString(t, ToMillis(0), `ToMillis(0)`)
+	assertString(t, ToMillis(2147483648000000), `ToMillis(2147483648000000)`)
+	assertString(t, ToMillis(Epoch(0, "second")), `ToMillis(Epoch(0, "second"))`)
+	assertString(t, ToMillis(Epoch(2147483648000, "millisecond")), `ToMillis(Epoch(2147483648000, "millisecond"))`)
+	assertString(t, ToMillis(0), `ToMillis(0)`)
+	assertString(t, ToMillis(2147483648000000), `ToMillis(2147483648000000)`)
+	assertString(t, ToSeconds(0), `ToSeconds(0)`)
+	assertString(t, ToSeconds(Epoch(2147483648, "second")), `ToSeconds(Epoch(2147483648, "second"))`)
+	assertString(t, ToSeconds(0), `ToSeconds(0)`)
+	assertString(t, ToSeconds(2147483648000000), `ToSeconds(2147483648000000)`)
+	assertString(t, Year(Epoch(0, "second")), `Year(Epoch(0, "second"))`)
+	assertString(t, Year(Epoch(2147483648, "second")), `Year(Epoch(2147483648, "second"))`)
+	assertString(t, Year(0), `Year(0)`)
+	assertString(t, Year(2147483648000000), `Year(2147483648000000)`)
+}
+
+func TestStringify0ArityFunctions(t *testing.T) {
+	assertString(t, Now(), `Now()`)
+
+	assertString(t, NewId(), `NewId()`)
+	assertString(t, NextID(), `NextID()`)
+	assertString(t, Indexes(), `Indexes()`)
+	assertString(t, Functions(), `Functions()`)
+	assertString(t, Roles(), `Roles()`)
+	assertString(t, Credentials(), `Credentials()`)
+	assertString(t, Tokens(), `Tokens()`)
+	assertString(t, Collections(), `Collections()`)
+	assertString(t, Databases(), `Databases()`)
+	assertString(t, Keys(), `Keys()`)
+	assertString(t, Classes(), `Classes()`)
+}
+
+func TestStringifyVariableFunctions(t *testing.T) {
+	assertString(t,
+		Paginate(Match(Index("idx")), After(Now()), Size(1), Before("yesterday"), EventsOpt(9), TS(Now())),
+		`Paginate(Match(Index("idx")), After(Now()), Before("yesterday"), EventsOpt(9), Size(1), TS(Now()))`,
+	)
+
+	assertString(t, Concat(Arr{"hey", "there"}), `Concat(Arr{"hey", "there"})`)
+	assertString(t, Concat(Arr{"hey", "there"}, Separator("/")), `Concat(Arr{"hey", "there"}, Separator("/"))`)
+
+	assertString(t,
+		ReplaceStrRegex("One FIsh Two fish", "[Ff][Ii]sh", "Dog", OnlyFirst()),
+		`ReplaceStrRegex("One FIsh Two fish", "[Ff][Ii]sh", "Dog", OnlyFirst())`,
+	)
+
+	assertString(t, SubString("ABCDEFZZZ", 3, StrLength(3)), `SubString("ABCDEFZZZ", 3, StrLength(3))`)
+
+	merge1 := Merge(Obj{}, Obj{"a": 1})
+	merge2 := Merge(Obj{"b": 2},
+		Obj{},
+		ConflictResolver(Lambda(Arr{"key", "left", "right"}, Var("right"))),
+	)
+	assertString(t, merge1, `Merge(Obj{}, Obj{"a": 1})`)
+	assertString(t, merge2, `Merge(Obj{"b": 2}, Obj{}, ConflictResolver(Lambda(Arr{"key", "left", "right"}, Var("right"))))`)
+
+	assertString(t, FindStr("One Fish Two Fish", "Fish", Start(8)), `FindStr("One Fish Two Fish", "Fish", Start(8))`)
+	assertString(t, Concat(Arr{"Hello", "World"}, Separator(" ")), `Concat(Arr{"Hello", "World"}, Separator(" "))`)
+
+	assertString(t, Trunc(5e-01, Precision(2)), `Trunc(5E-01, Precision(2))`)
+	assertString(t, Round(1.666666e+00, Precision(3)), `Round(1.666666E+00, Precision(3))`)
+
+	assertString(t, Casefold("Å", Normalizer("NFD")), `Casefold("Å", Normalizer("NFD"))`)
+	assertString(t, Casefold("Å", Normalizer("NFC")), `Casefold("Å", Normalizer("NFC"))`)
+	assertString(t, Casefold("ẛ̣", Normalizer("NFKD")), `Casefold("ẛ̣", Normalizer("NFKD"))`)
+	assertString(t, Casefold("ẛ̣", Normalizer("NFKC")), `Casefold("ẛ̣", Normalizer("NFKC"))`)
+	assertString(t, Casefold("Å", Normalizer("NFKCCaseFold")), `Casefold("Å", Normalizer("NFKCCaseFold"))`)
+
+	assertString(t, Exists(Function("a_function"), TS(0)), `Exists(Function("a_function"), TS(0))`)
+	assertString(t, Get(Function("a_function"), TS(0)), `Get(Function("a_function"), TS(0))`)
+}
+
+func TestStringifyVarArgFunctions(t *testing.T) {
+	assertString(t, Add(1, 2, 3), `Add(1, 2, 3)`)
+	assertString(t, Divide(1, 2, 3), `Divide(1, 2, 3)`)
+	assertString(t, Multiply(1, 2, 3), `Multiply(1, 2, 3)`)
+
+	assertString(t, Add(Var("x")), `Add(Var("x"))`)
+
+	assertString(t, BitOr(1, 2, 3), `BitOr(1, 2, 3)`)
+	assertString(t, Do(Arr{1, 2, 3}), `Do(Arr{1, 2, 3})`)
+	assertString(t, Equals(0, Modulo(Var("i"), 2)), `Equals(0, Modulo(Var("i"), 2))`)
+
+	assertString(t, Or(1, 2, 3), `Or(1, 2, 3)`)
+	assertString(t, And(1, 2, 3), `And(1, 2, 3)`)
+	assertString(t, BitOr(1, 2, 3), `BitOr(1, 2, 3)`)
+	assertString(t, BitXor(1, 2, 3), `BitXor(1, 2, 3)`)
+
+	assertString(t, Max(1, Var("x"), 3), `Max(1, Var("x"), 3)`)
+	assertString(t, Min(1, Var("x"), 3), `Min(1, Var("x"), 3)`)
+	assertString(t, Modulo(1, Var("x"), 3), `Modulo(1, Var("x"), 3)`)
+
+	assertString(t, LT(1, Var("x"), 3), `LT(1, Var("x"), 3)`)
+	assertString(t, GT(1, Var("x"), 3), `GT(1, Var("x"), 3)`)
+	assertString(t, LTE(1, Var("x"), 3), `LTE(1, Var("x"), 3)`)
+	assertString(t, GTE(1, Var("x"), 3), `GTE(1, Var("x"), 3)`)
+
+	assertString(t, Paginate(Union(
+		MatchTerm(Null(), "arcane"),
+		MatchTerm(Null(), "fire"),
+	)),
+		`Paginate(Union(MatchTerm(nil, "arcane"), MatchTerm(nil, "fire")))`)
+
+	assertString(t, Paginate(Difference(
+		MatchTerm(Null(), "arcane"),
+		MatchTerm(Null(), "fire"),
+	)),
+		`Paginate(Difference(MatchTerm(nil, "arcane"), MatchTerm(nil, "fire")))`)
+
+	assertString(t, Paginate(Intersection(
+		MatchTerm(Null(), "arcane"),
+		MatchTerm(Null(), "fire"),
+	)),
+		`Paginate(Intersection(MatchTerm(nil, "arcane"), MatchTerm(nil, "fire")))`)
+}
+
+func TestStringifyScopedFunctions(t *testing.T) {
+	assertString(t, NewId(), `NewId()`)
+	assertString(t, NextID(), `NextID()`)
+	assertString(t, ScopedIndexes(Database("db1")), `ScopedIndexes(Database("db1"))`)
+	assertString(t, ScopedFunctions(Database("db1")), `ScopedFunctions(Database("db1"))`)
+	assertString(t, ScopedRoles(Database("db1")), `ScopedRoles(Database("db1"))`)
+	assertString(t, ScopedCredentials(Database("db1")), `ScopedCredentials(Database("db1"))`)
+	assertString(t, ScopedTokens(Database("db1")), `ScopedTokens(Database("db1"))`)
+	assertString(t, ScopedCollections(Database("db1")), `ScopedCollections(Database("db1"))`)
+	assertString(t, ScopedDatabases(Database("db1")), `ScopedDatabases(Database("db1"))`)
+	assertString(t, ScopedKeys(Database("db1")), `ScopedKeys(Database("db1"))`)
+	assertString(t, ScopedClasses(Database("db1")), `ScopedClasses(Database("db1"))`)
+}
+
+func TestStringifyCustomFunctions(t *testing.T) {
+	let := Let().Bind("x", 90).Bind("y", 65).In(Add(Var("x"), Var("y")))
+	assertString(t, let, `Let().Bind("x", 90).Bind("y", 65).In(Add(Var("x"), Var("y")))`)
+
+	assertString(t, Match(Index("idx")), `Match(Index("idx"))`)
+	assertString(t, MatchTerm(Index("idx"), "term"), `MatchTerm(Index("idx"), "term")`)
+}


### PR DESCRIPTION
Go driver's string representations for various types is unfriendly and uninformative. This makes output friendlier.