### PR TITLE
DRV-24: Make Ref() accept 2 args

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ type User struct {
 func main() {
 	client := f.NewFaunaClient("your-secret-here")
 
-	res, err := client.Query(f.Get(f.RefCollection(f.Collection("user"), "42")))
+	res, err := client.Query(f.Get(f.Ref(f.Collection("user"), "42")))
 	if err != nil {
 		panic(err)
 	}

--- a/faunadb/client_test.go
+++ b/faunadb/client_test.go
@@ -525,7 +525,7 @@ func (s *ClientTestSuite) TestEvalDoExpression() {
 	var ref f.RefV
 
 	randomID := f.RandomStartingWith()
-	refToCreate := f.RefCollection(randomCollection, randomID)
+	refToCreate := f.Ref(randomCollection, randomID)
 
 	res := s.queryForRef(
 		f.Do(
@@ -1441,6 +1441,7 @@ func (s *ClientTestSuite) TestEvalRefFunctions() {
 		f.Arr{
 			f.Ref("collections/thing/123"),
 			f.RefCollection(f.Collection("thing"), "123"),
+			f.Ref(f.Collection("thing"), "123"),
 			f.Index("idx"),
 			f.Collection("cls"),
 			f.Database("db"),
@@ -1455,6 +1456,7 @@ func (s *ClientTestSuite) TestEvalRefFunctions() {
 
 	s.Require().Equal([]f.RefV{
 		f.RefV{"123", n1, n1, nil},
+		f.RefV{"123", n2, n2, nil},
 		f.RefV{"123", n2, n2, nil},
 		f.RefV{"idx", f.NativeIndexes(), f.NativeIndexes(), nil},
 		f.RefV{"cls", f.NativeCollections(), f.NativeCollections(), nil},

--- a/faunadb/query.go
+++ b/faunadb/query.go
@@ -206,13 +206,23 @@ func (lb *LetBuilder) In(in Expr) Expr {
 // Ref creates a new RefV value with the provided ID.
 //
 // Parameters:
-//  id string - A string representation of a reference type.
+//  idOrRef Ref - A class reference or string repr to reference type.
+//  id string - The document ID.
 //
 // Returns:
 //  Ref - A new reference type.
 //
 // See: https://app.fauna.com/documentation/reference/queryapi#special-type
-func Ref(id string) Expr { return fn1("@ref", id) }
+func Ref(idOrRef interface{}, id ...interface{}) Expr {
+	switch len(id) {
+	case 0:
+		return fn1("@ref", idOrRef)
+	case 1:
+		return RefCollection(idOrRef, id[0])
+	default:
+		panic("Ref() accepts between 1 and 2 arguments.")
+	}
+}
 
 // RefClass creates a new Ref based on the provided class and ID.
 //


### PR DESCRIPTION

Makes it possible to use

```go
f.Ref(f.Collection("user"), "42")
```