### PR TITLE
fix: illegal character.

### DIFF
--- a/faunadb/client.go
+++ b/faunadb/client.go
@@ -350,6 +350,6 @@ func parseTxnTimeHeader(header http.Header) (txnTime int64, err error) {
 }
 
 func basicAuth(secret string) string {
-	encoded := base64.StdEncoding.EncodeToString([]byte(secret))
-	return fmt.Sprintf("Basic %s:", encoded)
+	encoded := base64.StdEncoding.EncodeToString([]byte(secret + ":"))
+	return fmt.Sprintf("Basic %s", encoded)
 }


### PR DESCRIPTION
> Response error 500. Errors: [](internal server error): java.lang.IllegalArgumentException: Illegal base64 character 3a

Follow the same pattern as Java and JS about the encoding of the secret.

Java:
https://github.com/fauna/faunadb-jvm/blob/d087a89b27875b662fbd5ca648bea3a3b626254f/faunadb-common/src/main/java/com/faunadb/common/Connection.java#L477-L484

JS:
https://github.com/fauna/faunadb-js/blob/08a45a84fa20c511ef196b973f9a8a8866e6ed27/src/Client.js#L260