### PR TITLE
DRV-125: Support for versioned queries

### DIFF
--- a/faunadb/client.go
+++ b/faunadb/client.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	apiVersion        = "2.7"
+	apiVersion        = "3"
 	defaultEndpoint   = "https://db.fauna.com"
 	requestTimeout    = 60 * time.Second
 	headerTxnTime     = "X-Txn-Time"

--- a/faunadb/values.go
+++ b/faunadb/values.go
@@ -354,7 +354,8 @@ func (bytes BytesV) MarshalJSON() ([]byte, error) {
 
 // QueryV represents a `@query` value in FaunaDB.
 type QueryV struct {
-	lambda json.RawMessage
+	lambda     json.RawMessage
+	apiVersion string `json:"api_version,omitempty"`
 }
 
 // Get implements the Value interface by decoding the underlying value to a QueryV.
@@ -365,7 +366,7 @@ func (query QueryV) At(field Field) FieldValue { return field.get(query) }
 
 // String implements the Value interface by converting a QueryV to a string.
 func (query QueryV) String() string {
-	return "QueryV{" + string(query.lambda) + "}"
+	return "QueryV{" + string(query.lambda) + "," + query.apiVersion + "}"
 }
 
 // MarshalJSON implements json.Marshaler by escaping its value according to FaunaDB query representation.


### PR DESCRIPTION
Adds support to the driver for versioned lambda/query values which come back on the wire, specifically the new `api_version` field.

String repr changes will be applied in #107 