### PR TITLE
DRV-215: Tests for versioned queries

### DIFF
--- a/faunadb/client.go
+++ b/faunadb/client.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	apiVersion        = "2.7"
+	apiVersion        = "3"
 	defaultEndpoint   = "https://db.fauna.com"
 	requestTimeout    = 60 * time.Second
 	headerTxnTime     = "X-Txn-Time"

--- a/faunadb/deserialization_test.go
+++ b/faunadb/deserialization_test.go
@@ -178,6 +178,16 @@ func TestDeserializeQueryVInsideObjectV(t *testing.T) {
 	require.Equal(t, ObjectV{"a": StringV("a"), "b": ObjectV{"lambda": QueryV{lambda}}, "c": StringV("c")}, object)
 }
 
+func TestDeserializeVersionedQueryV(t *testing.T) {
+	var query QueryV
+
+	lambda1 := json.RawMessage(`{"lambda": "x", "api_version": "3", "expr": {"var": "x"}}`)
+
+	require.NoError(t, decodeJSON(`{"@query": {"lambda": "x", "api_version": "3", "expr": {"var": "x"}}}`, &query))
+	require.Equal(t, QueryV{lambda1}, query)
+
+}
+
 func TestDeserializeInvalidQueryV(t *testing.T) {
 	var object ObjectV
 


### PR DESCRIPTION
- No tests in client_test were added since lambda field in QueryV is not exported and `client_test.go` is in faunadb_test package
- Added a deserialization test

See #108 