### PR TITLE
DRV-348: Introduce streaming api

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,38 @@ commands:
           path: results/
 
 jobs:
+  core-stable-1-15-6:
+    executor:
+      name: core
+      go_version: "1.15.6"
+      version: stable
+    steps:
+      - build_and_test
+
+  core-nightly-1-15-6:
+    executor:
+      name: core
+      go_version: "1.15.6"
+      version: nightly
+    steps:
+      - build_and_test
+
+  core-stable-1-14-13:
+    executor:
+      name: core
+      go_version: "1.14.13"
+      version: stable
+    steps:
+      - build_and_test
+
+  core-nightly-1-14-13:
+    executor:
+      name: core
+      go_version: "1.14.13"
+      version: nightly
+    steps:
+      - build_and_test
+
   core-stable-1-13:
     executor:
       name: core
@@ -77,51 +109,19 @@ jobs:
     steps:
       - build_and_test
 
-  core-stable-1-12:
-    executor:
-      name: core
-      go_version: "1.12"
-      version: stable
-    steps:
-      - build_and_test
-
-  core-nightly-1-12:
-    executor:
-      name: core
-      go_version: "1.12"
-      version: nightly
-    steps:
-      - build_and_test
-
-  core-stable-1-11:
-    executor:
-      name: core
-      go_version: "1.11"
-      version: stable
-    steps:
-      - build_and_test
-
-  core-nightly-1-11:
-    executor:
-      name: core
-      go_version: "1.11"
-      version: nightly
-    steps:
-      - build_and_test
-
 workflows:
   version: 2
   build_and_test:
     jobs:
+      - core-stable-1-15-6:
+          context: faunadb-drivers
+      - core-nightly-1-15-6:
+          context: faunadb-drivers
+      - core-stable-1-14-13:
+          context: faunadb-drivers
+      - core-nightly-1-14-13:
+          context: faunadb-drivers
       - core-stable-1-13:
           context: faunadb-drivers
       - core-nightly-1-13:
-          context: faunadb-drivers
-      - core-stable-1-12:
-          context: faunadb-drivers
-      - core-nightly-1-12:
-          context: faunadb-drivers
-      - core-stable-1-11:
-          context: faunadb-drivers
-      - core-nightly-1-11:
           context: faunadb-drivers

--- a/faunadb/client.go
+++ b/faunadb/client.go
@@ -2,21 +2,29 @@ package faunadb
 
 import (
 	"bytes"
+	"context"
+	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"time"
+
+	"golang.org/x/net/http2"
 )
 
 const (
-	apiVersion        = "3"
+	apiVersion        = "4"
 	defaultEndpoint   = "https://db.fauna.com"
 	requestTimeout    = 60 * time.Second
+	streamTimeout     = 60 * time.Minute
 	headerTxnTime     = "X-Txn-Time"
 	headerLastSeenTxn = "X-Last-Seen-Txn"
 	headerFaunaDriver = "go"
@@ -77,6 +85,12 @@ type faunaRequest struct {
 	headers map[string]string
 }
 
+type faunaResponse struct {
+	response *http.Response
+	ctx      context.Context
+	cncl     context.CancelFunc
+}
+
 // ObserverCallback is the callback type for requests.
 type ObserverCallback func(*QueryResult)
 
@@ -94,6 +108,7 @@ If you need to create a client with a different secret, use the NewSessionClient
 type FaunaClient struct {
 	basicAuth        string
 	endpoint         string
+	streamEndpoint   string
 	http             *http.Client
 	isTxnTimeEnabled bool
 	lastTxnTime      int64
@@ -107,6 +122,8 @@ type QueryResult struct {
 	Client     *FaunaClient
 	Query      Expr
 	Result     Value
+	Event      StreamEvent
+	Streaming  bool
 	StatusCode int
 	Headers    map[string][]string
 	StartTime  time.Time
@@ -128,10 +145,25 @@ func NewFaunaClient(secret string, configs ...ClientConfig) *FaunaClient {
 	if client.endpoint == "" {
 		client.endpoint = defaultEndpoint
 	}
+	streamURI := "stream"
+	if client.endpoint[len(streamURI)-1:] != "/" {
+		streamURI = "/" + streamURI
+	}
+	client.streamEndpoint = client.endpoint + streamURI
 
 	if client.http == nil {
+		dial := func(network, addr string, cfg *tls.Config) (net.Conn, error) {
+			return net.Dial(network, addr)
+		}
+		if len(client.endpoint) > 5 && client.endpoint[:5] == "https" {
+			dial = nil
+		}
+		transport := &http2.Transport{
+			DialTLS:   dial,
+			AllowHTTP: true,
+		}
 		client.http = &http.Client{
-			Timeout: requestTimeout,
+			Transport: transport,
 		}
 	}
 
@@ -172,20 +204,32 @@ func (client *FaunaClient) BatchQueryResult(expr []Expr) (value []Value, headers
 
 // Query is the primary method used to send a query language expression to FaunaDB.
 func (client *FaunaClient) Query(expr Expr, configs ...QueryConfig) (value Value, err error) {
+	var response faunaResponse
+	var payload []byte
+
 	startTime := time.Now()
-	response, err := client.performRequest(expr, configs)
 
-	if response != nil {
-		defer func() {
-			_, _ = io.Copy(ioutil.Discard, response.Body) // Discard remaining bytes so the connection can be reused
-			_ = response.Body.Close()
-		}()
-	}
+	if payload, err = client.prepareRequestBody(expr); err == nil {
+		body := bytes.NewReader(payload)
 
-	if err == nil {
-		if err = checkForResponseErrors(response); err == nil {
-			value, err = client.parseResponse(response, expr, startTime)
+		response, err = client.performRequest(body, client.endpoint, false, configs)
+
+		httpResponse := response.response
+
+		if httpResponse != nil {
+			defer func() {
+				_, _ = io.Copy(ioutil.Discard, httpResponse.Body) // Discard remaining bytes so the connection can be reused
+				_ = httpResponse.Body.Close()
+				response.cncl()
+			}()
 		}
+
+		if err == nil {
+			if err = checkForResponseErrors(httpResponse); err == nil {
+				value, err = client.parseResponse(httpResponse, expr, false, startTime)
+			}
+		}
+
 	}
 
 	return
@@ -219,6 +263,100 @@ func (client *FaunaClient) NewWithObserver(observer ObserverCallback) *FaunaClie
 	return client.newClient(client.basicAuth, observer)
 }
 
+// Stream creates a stream subscription to the result of the given expression.
+//
+// The subscription returned by this method does not issue any requests until
+// the subscription's Start method is called. Make sure to
+// subscribe to the events of interest, otherwise the received events are simply
+// ignored.
+func (client *FaunaClient) Stream(query Expr, config ...StreamConfig) StreamSubscription {
+	return newSubscription(client, query, config...)
+}
+
+func (client *FaunaClient) startStream(subscription *StreamSubscription) (err error) {
+	if subscription.Status() != StreamConnIdle {
+		err = errors.New("stream subscription already started")
+		return
+	}
+
+	startTime := time.Now()
+	if payload, err := client.prepareRequestBody(subscription.query); err == nil {
+		body := ioutil.NopCloser(bytes.NewReader(payload))
+
+		var endpoint strings.Builder
+		endpoint.WriteString(client.streamEndpoint)
+
+		if len(subscription.config.Fields) > 0 {
+			endpoint.WriteString("?fields=")
+			count := len(subscription.config.Fields)
+			for i := 0; i < count; i++ {
+				endpoint.WriteString(string(subscription.config.Fields[i]))
+				if i <= count-1 {
+					endpoint.WriteString(",")
+				}
+			}
+		}
+
+		subscription.status.Set(StreamConnOpening)
+		if response, err := client.performRequest(body, endpoint.String(), true, nil); err == nil {
+			httpResponse := response.response
+			_ = client.storeLastTxnTime(httpResponse.Header)
+			if err = checkForResponseErrors(httpResponse); err != nil {
+
+				subscription.status.Set(StreamConnError)
+				subscription.dispatcher.Dispatch(ErrorEvent{
+					txn: startTime.Unix(),
+					err: err,
+				})
+
+				httpResponse.Body.Close()
+				response.cncl()
+				return err
+			}
+
+			go func() {
+				subscription.status.Set(StreamConnActive)
+
+				defer httpResponse.Body.Close()
+				defer response.cncl()
+
+				for {
+					if subscription.status.Get() != StreamConnActive {
+						break
+					}
+
+					var val Value
+					var obj Obj
+
+					if val, err = client.parseResponse(httpResponse, subscription.query, true, startTime); err == nil {
+						if err = val.Get(&obj); err == nil {
+							var event StreamEvent
+							if event, err = unMarshalStreamEvent(obj); err == nil {
+								client.SyncLastTxnTime(event.Txn())
+								subscription.dispatcher.Dispatch(event)
+							}
+						}
+					} else {
+						if err == io.EOF {
+							subscription.status.Set(StreamConnClosed)
+						} else {
+							subscription.status.Set(StreamConnError)
+						}
+						subscription.dispatcher.Dispatch(ErrorEvent{
+							txn: startTime.Unix(),
+							err: err,
+						})
+						break
+					}
+				}
+			}()
+
+		}
+	}
+
+	return
+}
+
 // GetLastTxnTime gets the freshest timestamp reported to this client.
 func (client *FaunaClient) GetLastTxnTime() int64 {
 	if client.isTxnTimeEnabled {
@@ -248,6 +386,7 @@ func (client *FaunaClient) newClient(basicAuth string, observer ObserverCallback
 	return &FaunaClient{
 		basicAuth:        basicAuth,
 		endpoint:         client.endpoint,
+		streamEndpoint:   client.streamEndpoint,
 		headers:          client.headers,
 		http:             client.http,
 		isTxnTimeEnabled: client.isTxnTimeEnabled,
@@ -257,62 +396,85 @@ func (client *FaunaClient) newClient(basicAuth string, observer ObserverCallback
 	}
 }
 
-func (client *FaunaClient) performRequest(expr Expr, configs []QueryConfig) (response *http.Response, err error) {
+func (client *FaunaClient) performRequest(body io.Reader, endpoint string, streaming bool, configs []QueryConfig) (response faunaResponse, err error) {
 	var request *http.Request
-	if request, err = client.prepareRequest(expr, configs); err == nil {
-		response, err = client.http.Do(request)
+	var timeout time.Duration = requestTimeout
+	if streaming {
+		timeout = streamTimeout
+	}
+	response.ctx, response.cncl = context.WithTimeout(context.Background(), timeout)
+	if request, err = client.prepareRequest(response.ctx, body, endpoint, configs); err == nil {
+		response.response, err = client.http.Do(request)
 	}
 
 	return
 }
 
-func (client *FaunaClient) prepareRequest(expr Expr, configs []QueryConfig) (request *http.Request, err error) {
-	var body []byte
+func (client *FaunaClient) prepareRequestBody(expr Expr) (payload []byte, err error) {
+	payload, err = json.Marshal(expr)
+	return
+}
 
-	if body, err = json.Marshal(expr); err == nil {
-		if request, err = http.NewRequest("POST", client.endpoint, bytes.NewReader(body)); err == nil {
-			request.Header.Add("Authorization", client.basicAuth)
-			for k, v := range client.headers {
+func (client *FaunaClient) prepareRequest(ctx context.Context, body io.Reader, endpoint string, configs []QueryConfig) (request *http.Request, err error) {
+	if request, err = http.NewRequestWithContext(ctx, "POST", endpoint, body); err == nil {
+		request.Header.Add("Authorization", client.basicAuth)
+		for k, v := range client.headers {
+			request.Header.Add(k, v)
+		}
+
+		if len(configs) > 0 {
+			req := &faunaRequest{
+				headers: map[string]string{},
+			}
+			for _, config := range configs {
+				config(req)
+			}
+			for k, v := range req.headers {
 				request.Header.Add(k, v)
 			}
-
-			if len(configs) > 0 {
-				req := &faunaRequest{
-					headers: map[string]string{},
-				}
-				for _, config := range configs {
-					config(req)
-				}
-				for k, v := range req.headers {
-					request.Header.Add(k, v)
-				}
-			}
-
-			client.addLastTxnTimeHeader(request)
 		}
+
+		client.addLastTxnTimeHeader(request)
 	}
 
 	return
 }
 
-func (client *FaunaClient) parseResponse(response *http.Response, expr Expr, startTime time.Time) (value Value, err error) {
+func (client *FaunaClient) parseResponse(response *http.Response, expr Expr, streaming bool, startTime time.Time) (value Value, err error) {
 	var parsedResponse Value
 
-	if err = client.storeLastTxnTime(response.Header); err == nil {
-		if parsedResponse, err = parseJSON(response.Body); err == nil {
-			value, err = parsedResponse.At(resource).GetValue()
-			client.callObserver(response, expr, value, startTime)
+	if !streaming {
+		if err = client.storeLastTxnTime(response.Header); err != nil {
+			return
 		}
+	}
+
+	if parsedResponse, err = parseJSON(response.Body); err == nil {
+		if streaming {
+			value = parsedResponse
+		} else {
+			value, err = parsedResponse.At(resource).GetValue()
+		}
+		client.callObserver(response, expr, streaming, value, startTime)
 	}
 
 	return
 }
 
-func (client *FaunaClient) callObserver(response *http.Response, expr Expr, value Value, startTime time.Time) {
+func (client *FaunaClient) callObserver(response *http.Response, expr Expr, streaming bool, value Value, startTime time.Time) {
+	var event StreamEvent
+	if streaming {
+		var obj Obj
+		value.Get(&obj)
+		event, _ = unMarshalStreamEvent(obj)
+		value = nil
+	}
 	queryResult := &QueryResult{
 		client,
 		expr,
 		value,
+		event,
+		streaming,
 		response.StatusCode,
 		response.Header,
 		startTime,

--- a/faunadb/errors.go
+++ b/faunadb/errors.go
@@ -1,8 +1,10 @@
 package faunadb
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 )
 
@@ -115,4 +117,25 @@ func parseErrorResponse(response *http.Response) FaunaError {
 	}
 
 	return errorResponse{false, response.StatusCode, errors}
+}
+
+func errorFromStreamError(obj ObjectV) (err error) {
+	var sb strings.Builder
+	sb.WriteString("stream_error:")
+	keys := make([]string, len(obj))
+	for k := range obj {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		if _, ok := obj[k]; ok {
+			sb.WriteString(" ")
+			sb.WriteString(k)
+			sb.WriteString("=")
+			sb.WriteString(fmt.Sprintf("'%s'", obj[k]))
+		}
+
+	}
+	err = errors.New(sb.String())
+	return
 }

--- a/faunadb/stream.go
+++ b/faunadb/stream.go
@@ -1,0 +1,78 @@
+package faunadb
+
+// StreamField represents a stream field
+type StreamField string
+
+const (
+	DiffField     StreamField = "diff"
+	PrevField     StreamField = "prev"
+	DocumentField StreamField = "document"
+	ActionField   StreamField = "action"
+)
+
+type streamConfig struct {
+	Fields []StreamField
+}
+
+// StreamEventCallback describes the listener function for a
+// stream event
+type StreamEventCallback func(StreamEvent)
+
+// StreamConfig describes optional parameters for a stream subscription
+type StreamConfig func(*StreamSubscription)
+
+// StreamConnectionStatus is a expression shortcut to represent
+// the stream connection status
+type StreamConnectionStatus int
+
+const (
+	// StreamConnIdle represents an idle stream subscription
+	StreamConnIdle StreamConnectionStatus = iota
+	// StreamConnOpening describes an opening stream subscription
+	StreamConnOpening
+	// StreamConnActive describes an active/established stream subscription
+	StreamConnActive
+	// StreamConnClosed describes a closed stream subscription
+	StreamConnClosed
+	// StreamConnError describes a stream subscription error
+	StreamConnError
+)
+
+// Fields is optional stream parameter that describes the fields received on version and history_rewrite stream events.
+func Fields(fields ...StreamField) StreamConfig {
+	return func(sub *StreamSubscription) {
+		sub.config.Fields = []StreamField(fields)
+	}
+}
+
+// OnStart is an optional stream parameter that specifies the listener function for the start event
+// alternatively `subscription.On(f.StartEventT, fn)` can be used
+func OnStart(fn StreamEventCallback) StreamConfig {
+	return func(sub *StreamSubscription) {
+		sub.dispatcher.On(StartEventT, fn)
+	}
+}
+
+// OnVersion is an optional stream parameter that specifies the listener function for a version event
+// alternatively `subscription.On(f.VersionEventT, fn)` can be used
+func OnVersion(fn StreamEventCallback) StreamConfig {
+	return func(sub *StreamSubscription) {
+		sub.dispatcher.On(VersionEventT, fn)
+	}
+}
+
+// OnError is an optional stream parameter that specifies the listener function for an error event
+// alternatively `subscription.On(f.ErrorEventT, fn)` can be used
+func OnError(fn StreamEventCallback) StreamConfig {
+	return func(sub *StreamSubscription) {
+		sub.dispatcher.On("error", fn)
+	}
+}
+
+// OnHistoryRewrite is an optional stream parameter that specifies the listener function for a history rewrite event
+// alternatively `subscription.On(f.HistoryRewriteEventT, fn)` can be used
+func OnHistoryRewrite(fn StreamEventCallback) StreamConfig {
+	return func(sub *StreamSubscription) {
+		sub.dispatcher.On("history_rewrite", fn)
+	}
+}

--- a/faunadb/stream_dispatcher.go
+++ b/faunadb/stream_dispatcher.go
@@ -1,0 +1,38 @@
+package faunadb
+
+type streamDispatcher struct {
+	OnError   StreamEventCallback
+	OnHistory StreamEventCallback
+	OnStart   StreamEventCallback
+	OnVersion StreamEventCallback
+}
+
+func (dispatch *streamDispatcher) On(eventType StreamEventType, callback StreamEventCallback) {
+	switch eventType {
+	case ErrorEventT:
+		dispatch.OnError = callback
+	case StartEventT:
+		dispatch.OnStart = callback
+	case VersionEventT:
+		dispatch.OnVersion = callback
+	case HistoryRewriteEventT:
+		dispatch.OnHistory = callback
+	}
+}
+
+func (dispatch streamDispatcher) Dispatch(event StreamEvent) {
+	var fn StreamEventCallback
+	switch event.Type() {
+	case StartEventT:
+		fn = dispatch.OnStart
+	case VersionEventT:
+		fn = dispatch.OnVersion
+	case ErrorEventT:
+		fn = dispatch.OnError
+	case HistoryRewriteEventT:
+		fn = dispatch.OnHistory
+	default:
+		return
+	}
+	fn(event)
+}

--- a/faunadb/stream_events.go
+++ b/faunadb/stream_events.go
@@ -1,0 +1,165 @@
+package faunadb
+
+import (
+	"fmt"
+)
+
+// StreamEventType is a stream eveny type
+type StreamEventType = string
+
+const (
+	// ErrorEventT is the stream error event type
+	ErrorEventT StreamEventType = "error"
+
+	// HistoryRewriteEventT is the stream history rewrite event type
+	HistoryRewriteEventT StreamEventType = "history_rewrite"
+
+	// StartEventT is the stream start event type
+	StartEventT StreamEventType = "start"
+
+	// VersionEventT is the stream version event type
+	VersionEventT StreamEventType = "version"
+)
+
+// StreamEvent represents a stream event with a `type` and `txn`
+type StreamEvent interface {
+	Type() StreamEventType
+	Txn() int64
+	String() string
+}
+
+// StartEvent emitted when a valid stream subscription begins.
+// Upcoming events are guaranteed to have transaction timestamps equal to or greater than
+// the stream's start timestamp.
+type StartEvent struct {
+	StreamEvent
+	txn   int64
+	event int64
+}
+
+func unMarshalStreamEvent(data Obj) (evt StreamEvent, err error) {
+	switch StreamEventType(data["type"].(StringV)) {
+	case StartEventT:
+		evt = StartEvent{
+			txn:   int64(data["txn"].(LongV)),
+			event: int64(data["event"].(LongV)),
+		}
+	case VersionEventT:
+		evt = VersionEvent{
+			txn:   int64(data["txn"].(LongV)),
+			event: data["event"].(ObjectV),
+		}
+	case ErrorEventT:
+		evt = ErrorEvent{
+			txn: int64(data["txn"].(LongV)),
+			err: errorFromStreamError(data["event"].(ObjectV)),
+		}
+
+	case HistoryRewriteEventT:
+		evt = HistoryRewriteEvent{
+			txn:   int64(data["txn"].(LongV)),
+			event: data["event"].(ObjectV),
+		}
+	}
+	return
+}
+
+// Type returns the stream event type
+func (event StartEvent) Type() StreamEventType {
+	return StartEventT
+}
+
+// Txn returns the stream event timestamp
+func (event StartEvent) Txn() int64 {
+	return event.txn
+}
+
+// Event returns the stream event as a `f.ObjectV`
+func (event StartEvent) Event() int64 {
+	return event.event
+}
+
+func (event StartEvent) String() string {
+	return fmt.Sprintf("StartEvent{event=%d, txn=%d} ", event.Event(), event.Txn())
+}
+
+// VersionEvent represents a version event that occurs upon any
+// modifications to the current state of the subscribed document.
+type VersionEvent struct {
+	StreamEvent
+	txn   int64
+	event ObjectV
+}
+
+// Txn returns the stream event timestamp
+func (event VersionEvent) Txn() int64 {
+	return event.txn
+}
+
+// Event returns the stream event as a `f.ObjectV`
+func (event VersionEvent) Event() ObjectV {
+	return event.event
+}
+
+func (event VersionEvent) String() string {
+	return fmt.Sprintf("VersionEvent{txn=%d, event=%s}", event.Txn(), event.Event())
+}
+
+// Type returns the stream event type
+func (event VersionEvent) Type() StreamEventType {
+	return VersionEventT
+}
+
+// HistoryRewriteEvent represents a history rewrite event which occurs upon any modifications
+// to the history of the subscribed document.
+type HistoryRewriteEvent struct {
+	StreamEvent
+	txn   int64
+	event ObjectV
+}
+
+// Txn returns the stream event timestamp
+func (event HistoryRewriteEvent) Txn() int64 {
+	return event.txn
+}
+
+// Event returns the stream event as a `f.ObjectV`
+func (event HistoryRewriteEvent) Event() ObjectV {
+	return event.event
+}
+
+func (event HistoryRewriteEvent) String() string {
+	return fmt.Sprintf("HistoryRewriteEvent{txn=%d, event=%s}", event.Txn(), event.Event())
+}
+
+// Type returns the stream event type
+func (event HistoryRewriteEvent) Type() StreamEventType {
+	return VersionEventT
+}
+
+// ErrorEvent represents an error event fired both for client and server errors
+// that may occur as a result of a subscription.
+type ErrorEvent struct {
+	StreamEvent
+	txn int64
+	err error
+}
+
+// Type returns the stream event type
+func (event ErrorEvent) Type() StreamEventType {
+	return ErrorEventT
+}
+
+// Txn returns the stream event timestamp
+func (event ErrorEvent) Txn() int64 {
+	return event.txn
+}
+
+// Error returns the event error
+func (event ErrorEvent) Error() error {
+	return event.err
+}
+
+func (event ErrorEvent) String() string {
+	return fmt.Sprintf("ErrorEvent{error=%s}", event.err)
+}

--- a/faunadb/stream_subscription.go
+++ b/faunadb/stream_subscription.go
@@ -1,0 +1,71 @@
+package faunadb
+
+import "sync"
+
+func newSubscription(client *FaunaClient, query Expr, config ...StreamConfig) StreamSubscription {
+	sub := StreamSubscription{
+		query,
+		streamDispatcher{},
+		streamConfig{
+			[]StreamField{},
+		},
+		client,
+		streamConnectionStatus{status: StreamConnIdle},
+	}
+	for _, fn := range config {
+		fn(&sub)
+	}
+	return sub
+}
+
+type streamConnectionStatus struct {
+	mu     sync.Mutex
+	status StreamConnectionStatus
+}
+
+func (s *streamConnectionStatus) Set(status StreamConnectionStatus) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.status = status
+}
+
+func (s *streamConnectionStatus) Get() StreamConnectionStatus {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.status
+}
+
+// StreamSubscription dispatches events received to the registered listener functions.
+// New subscriptions must be constructed via the FaunaClient stream method.
+type StreamSubscription struct {
+	query      Expr
+	dispatcher streamDispatcher
+	config     streamConfig
+	client     *FaunaClient
+	status     streamConnectionStatus
+}
+
+// Query returns the query used to initiate the stream
+func (sub *StreamSubscription) Query() Expr {
+	return sub.query
+}
+
+// Status returns the current stream status
+func (sub *StreamSubscription) Status() StreamConnectionStatus {
+	return sub.status.Get()
+}
+
+// Start initiates the stream subscription.
+func (sub *StreamSubscription) Start() error {
+	return sub.client.startStream(sub)
+}
+
+// On
+func (sub *StreamSubscription) On(eventType StreamEventType, callback StreamEventCallback) {
+	sub.dispatcher.On(eventType, callback)
+}
+
+// Close eventually closes the stream
+func (sub *StreamSubscription) Close() {
+	sub.status.Set(StreamConnClosed)
+}

--- a/faunadb/stream_test.go
+++ b/faunadb/stream_test.go
@@ -1,0 +1,347 @@
+package faunadb_test
+
+import (
+	"io"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	f "github.com/fauna/faunadb-go/v3/faunadb"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestRunStreamTests(t *testing.T) {
+	suite.Run(t, new(StreamsTestSuite))
+}
+
+type StreamsTestSuite struct {
+	suite.Suite
+	client *f.FaunaClient
+}
+
+var (
+	streamCollection f.RefV
+)
+
+type counterMutex struct {
+	mu sync.Mutex
+	i  int64
+}
+
+func (c *counterMutex) Inc() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.i = c.i + 1
+}
+
+func (c *counterMutex) Value() int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.i
+}
+
+func (s *StreamsTestSuite) TestStreamDocumentRef() {
+	var wg sync.WaitGroup
+	var sub f.StreamSubscription
+
+	ref := s.createDocument()
+
+	wg.Add(1)
+
+	sub = s.client.Stream(ref, f.OnStart(func(e f.StreamEvent) {
+		evt := e.(f.StartEvent)
+		s.NotZero(evt.Txn())
+		s.NotZero(evt.Txn())
+		s.client.Query(f.Update(ref, f.Obj{"data": f.Obj{"x": time.Now().String()}}))
+
+	}), f.OnVersion(func(evt f.StreamEvent) {
+		s.Equal(evt.Type(), f.VersionEventT)
+		wg.Done()
+	}), f.OnError(s.defaultStreamError))
+
+	sub.Start()
+	wg.Wait()
+}
+
+func (s *StreamsTestSuite) TestRejectNonReadOnlyQuery() {
+	var wg sync.WaitGroup
+	query := f.CreateCollection(f.Obj{"name": "collection"})
+
+	wg.Add(1)
+
+	sub := s.client.Stream(query)
+	sub.On("start", func(se f.StreamEvent) { s.FailNow(se.String()) })
+	sub.On(f.ErrorEventT, func(se f.StreamEvent) {
+		s.Equal(se.Type(), f.ErrorEventT)
+		evt := se.(f.ErrorEvent)
+		s.EqualError(evt.Error(), "Response error 400. Errors: [](invalid expression): Write effect in read-only query expression.")
+		wg.Done()
+	})
+	sub.Start()
+	wg.Wait()
+}
+
+func (s *StreamsTestSuite) TestSelectFields() {
+	var wg sync.WaitGroup
+	ref := s.createDocument()
+
+	wg.Add(1)
+	sub := s.client.Stream(ref, f.Fields("diff", "prev", "document"))
+	sub.On("error", s.defaultStreamError)
+	sub.On("start", func(se f.StreamEvent) {
+		s.Equal(f.StartEventT, se.Type())
+		s.NotZero(se.Txn())
+		e := se.(f.StartEvent)
+		s.NotNil(e.Event())
+
+		s.client.Query(f.Update(ref, f.Obj{"data": f.Obj{"x": time.Now().String()}}))
+	})
+
+	sub.On("version", func(se f.StreamEvent) {
+		s.Equal(f.VersionEventT, se.Type())
+		s.NotZero(se.Txn())
+		evt := se.(f.VersionEvent)
+		body := evt.Event()
+		s.NotNil(body)
+
+		s.True(s.keyInMap("diff", body))
+		s.True(s.keyInMap("prev", body))
+		s.True(s.keyInMap("document", body))
+		s.False(s.keyInMap("action", body))
+
+		wg.Done()
+	})
+
+	sub.Start()
+	wg.Wait()
+}
+
+func (s *StreamsTestSuite) TestMultipleActiveStreams() {
+	var wg sync.WaitGroup
+	var counter counterMutex
+	var activeStreams int64 = 101
+
+	wg.Add(int(activeStreams))
+
+	for i := 0; i < int(activeStreams); i++ {
+
+		ref := s.createDocument()
+		sub := s.client.Stream(ref)
+
+		sub.On("error", s.defaultStreamError)
+
+		sub.On("start", func(se f.StreamEvent) {
+			s.Equal(f.StartEventT, se.Type())
+			s.NotZero(se.Txn())
+			e := se.(f.StartEvent)
+			s.NotNil(e.Event())
+
+			_, err := s.client.Query(f.Update(ref, f.Obj{"data": f.Obj{"x": time.Now().String()}}))
+			s.NoError(err)
+		})
+
+		sub.On("version", func(se f.StreamEvent) {
+			s.Equal(f.VersionEventT, se.Type())
+			s.NotZero(se.Txn())
+			evt := se.(f.VersionEvent)
+			body := evt.Event()
+			s.NotNil(body)
+
+			counter.Inc()
+
+			for {
+				if counter.Value() == activeStreams {
+					break
+				}
+				runtime.Gosched()
+			}
+
+			wg.Done()
+		})
+
+		sub.Start()
+	}
+
+	wg.Wait()
+	s.Require().Equal(activeStreams, counter.Value())
+}
+
+func (s *StreamsTestSuite) TestUpdateLastTxnTime() {
+	var wg sync.WaitGroup
+	ref := s.createDocument()
+	lastTxnTime := s.client.GetLastTxnTime()
+
+	wg.Add(1)
+	sub := s.client.Stream(ref)
+	sub.On("error", s.defaultStreamError)
+	sub.On("start", func(se f.StreamEvent) {
+		s.Equal(f.StartEventT, se.Type())
+		s.NotZero(se.Txn())
+		e := se.(f.StartEvent)
+		s.NotNil(e.Event())
+
+		s.Greater(s.client.GetLastTxnTime(), lastTxnTime)
+		s.GreaterOrEqual(s.client.GetLastTxnTime(), e.Txn())
+
+		s.client.Query(f.Update(ref, f.Obj{"data": f.Obj{"x": time.Now().String()}}))
+	})
+
+	sub.On("version", func(se f.StreamEvent) {
+		s.Equal(f.VersionEventT, se.Type())
+
+		s.NotZero(se.Txn())
+		s.Equal(se.Txn(), s.client.GetLastTxnTime())
+
+		wg.Done()
+	})
+	sub.Start()
+	wg.Wait()
+}
+
+func (s *StreamsTestSuite) TestHandleBadQuery() {
+	var wg sync.WaitGroup
+	query := f.StringV("just a boring string")
+
+	wg.Add(1)
+
+	sub := s.client.Stream(query)
+	sub.On("start", func(se f.StreamEvent) { s.FailNow(se.String()) })
+	sub.On(f.ErrorEventT, func(se f.StreamEvent) {
+		s.Equal(se.Type(), f.ErrorEventT)
+		evt := se.(f.ErrorEvent)
+		s.EqualError(evt.Error(), "Response error 400. Errors: [](invalid argument): Expected a Document Ref or Version, got String.")
+		wg.Done()
+	})
+	sub.Start()
+	wg.Wait()
+}
+
+func (s *StreamsTestSuite) TestStartActiveStream() {
+	var wg sync.WaitGroup
+	query := s.createDocument()
+
+	wg.Add(1)
+
+	sub := s.client.Stream(query)
+	sub.On(f.ErrorEventT, s.defaultStreamError)
+
+	sub.On("start", func(se f.StreamEvent) {
+		s.Require().Equal(f.StreamConnActive, sub.Status())
+		s.Require().EqualError(sub.Start(), "stream subscription already started")
+		sub.Close()
+		wg.Done()
+	})
+
+	s.Equal(f.StreamConnIdle, sub.Status())
+	sub.Start()
+
+	wg.Wait()
+	s.Equal(f.StreamConnClosed, sub.Status())
+}
+
+func (s *StreamsTestSuite) TestAuthRevalidation() {
+	var wg sync.WaitGroup
+	ref := s.createDocument()
+
+	wg.Add(1)
+
+	serverKey, err := f.CreateKeyWithRole("server")
+	s.Require().NoError(err)
+	var secret string
+	var serverKeyRef f.RefV
+	serverKey.At(f.ObjKey("secret")).Get(&secret)
+	serverKey.At(f.ObjKey("ref")).Get(&serverKeyRef)
+	client := s.client.NewSessionClient(secret)
+
+	sub := client.Stream(ref)
+	sub.On("start", func(se f.StreamEvent) {
+		s.Equal(f.StartEventT, se.Type())
+		s.NotZero(se.Txn())
+		e := se.(f.StartEvent)
+		s.NotNil(e.Event())
+
+		_, err := f.AdminQuery(f.Delete(serverKeyRef))
+		s.Require().NoError(err)
+
+		s.client.Query(f.Update(ref, f.Obj{"data": f.Obj{"x": time.Now().String()}}))
+	})
+
+	sub.On("version", func(se f.StreamEvent) {})
+
+	sub.On("error", func(se f.StreamEvent) {
+		evt := se.(f.ErrorEvent)
+		if evt.Error() == io.EOF {
+			return
+		}
+		s.EqualError(evt.Error(), `stream_error: code='permission denied' description='Authorization lost during stream evaluation.'`)
+		wg.Done()
+	})
+
+	sub.Start()
+	wg.Wait()
+
+}
+
+func (s *StreamsTestSuite) defaultStreamError(evt f.StreamEvent) {
+	s.Equal(f.ErrorEventT, evt.Type())
+	s.NotZero(evt.Txn())
+	e := evt.(f.ErrorEvent)
+	s.FailNow(e.Error().Error())
+}
+
+func (s *StreamsTestSuite) keyInMap(key string, m f.ObjectV) (ok bool) {
+	_, ok = m[key]
+	return
+}
+
+func (s *StreamsTestSuite) SetupSuite() {
+	client, err := f.SetupTestDB()
+	s.Require().NoError(err)
+
+	s.client = client
+	s.setupSchema()
+}
+
+func (s *StreamsTestSuite) setupSchema() {
+	val := s.query(
+		f.CreateCollection(f.Obj{"name": "streams_collection"}),
+	)
+	val.At(refField).Get(&streamCollection)
+}
+
+func (s *StreamsTestSuite) TearDownSuite() {
+	f.DeleteTestDB()
+}
+
+func (s *StreamsTestSuite) query(expr f.Expr) f.Value {
+	value, err := s.client.Query(expr)
+	s.Require().NoError(err)
+
+	return value
+}
+
+func (s *StreamsTestSuite) createDocument(data ...interface{}) (ref f.RefV) {
+	value, err := s.client.Query(f.Create(streamCollection, f.Obj{"data": f.Obj{"v": data}}))
+	s.Require().NoError(err)
+	value.At(refField).Get(&ref)
+
+	return
+}
+
+func (s *StreamsTestSuite) queryAndDecode(expr f.Expr, i interface{}) {
+	value := s.query(expr)
+	s.Require().NoError(value.Get(i))
+}
+
+func (s *StreamsTestSuite) adminQueryAndDecode(expr f.Expr, i interface{}) {
+	value := s.adminQuery(expr)
+	s.Require().NoError(value.Get(i))
+}
+
+func (s *StreamsTestSuite) adminQuery(expr f.Expr) (value f.Value) {
+	value, err := f.AdminQuery(expr)
+	s.Require().NoError(err)
+
+	return
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/fauna/faunadb-go/v3
 require (
 	github.com/fauna/faunadb-go v2.0.0+incompatible // indirect
 	github.com/stretchr/testify v1.6.1
+	golang.org/x/net v0.0.0-20201207224615-747e23833adb
 )
 
 go 1.14


### PR DESCRIPTION
This PR introduces the Go driver streaming API. 

 ## Streaming API
```go
import(
    f "github.com/fauna/faunadb-go/v3/faunadb"
    "log"
)

client := f.NewFaunaClient("secret")
var ref Ref.V = createDocument(data)

//Basic usage Pattern 1
var subscription f.StreamSubscription = client.Stream(ref)
subscription.On(f.StartEventT, func(se f.StreamEvent){
    log.Println("Received event ", se)
})
subscription.Start()

//Pattern 2 with optional stream parameters passed to client.Stream
startFn := func(se f.StreamEvent){ log.Println("start_evt ", se) }
subscription = client.Stream(ref, f.Fields(f.DiffField, f.DocumentField), 
    f.OnStart(startFn),
    f.OnError(func(se f.StreamEvent){
       errEvent := se.(f.ErrorEvent)
       log.Println("Received error event ", errEvent)
    }),
)
subscription.Start()
```

- Drops support for go.version < 1.13 (explained below)
- Api version bumped to 4
- Adds golang.org/x/net/http2 module for HTTP/2 support
- Switch to `http2.Transport` for all requests.
- Uses `context.Context` to impose deadlines on requests instead of relying on `HttpClient.Timeout` for timeouts.
   This change introduces faunaResponse type which stores the http response along with the context and cancel function `context.CancelFunc`. This allows for different request timeouts for query and stream connections, set at 60 seconds and 1 hour respectively.
   `http.NewRequestWithContext` is introduced in go 1.13 forcing us to drop support for versions < 1.13 https://golang.org/pkg/net/http/#NewRequestWithContext . 
 
- Tests up to 101 concurrent streams
- Each started subscription has an event loop running as a goroutine with received stream events dispatched as new goroutines 
- An ErrorEvent is triggered on `io.EOF` and related server/client errors. The connection is eventually closed and the subscription status updated.
