### PR TITLE
DRV-368: Added support for omitempty field tag

### DIFF
--- a/faunadb/deserialization_test.go
+++ b/faunadb/deserialization_test.go
@@ -325,6 +325,18 @@ func TestDeserializeStructWithIgnoredFields(t *testing.T) {
 	require.Equal(t, object{"Jhon", 0}, obj)
 }
 
+func TestDeserializeStructWithOmitEmptyTags(t *testing.T) {
+	type object struct {
+		Name string `fauna:"name,omitempty"`
+		Age  int64  `fauna:"age,omitempty"`
+	}
+
+	var obj object
+
+	require.NoError(t, decodeJSON(`{ "name": "Jhon", "age": 0 }`, &obj))
+	require.Equal(t, object{"Jhon", 0}, obj)
+}
+
 func TestDeserializeStructWithPointers(t *testing.T) {
 	type inner struct{ Name string }
 	type object struct{ Inner *inner }

--- a/faunadb/reflect.go
+++ b/faunadb/reflect.go
@@ -1,6 +1,8 @@
 package faunadb
 
-import "reflect"
+import (
+	"reflect"
+)
 
 func structToMap(aStruct reflect.Value) map[string]interface{} {
 	res := make(map[string]interface{}, aStruct.NumField())
@@ -10,6 +12,28 @@ func structToMap(aStruct reflect.Value) map[string]interface{} {
 	}
 
 	return res
+}
+
+func allStructFields(aStruct reflect.Value) map[string]reflect.Value {
+	fields := make(map[string]reflect.Value)
+	aStructType := aStruct.Type()
+
+	for i, size := 0, aStruct.NumField(); i < size; i++ {
+		field := aStruct.Field(i)
+		structTypeField := aStructType.Field(i)
+		if !field.CanInterface() {
+			continue
+		}
+
+		fieldName, ignore, _, _ := parseTag(aStructType.Field(i))
+
+		if !ignore && fieldName != "" {
+			fields[fieldName] = field
+		}
+		fields[structTypeField.Name] = field
+	}
+
+	return fields
 }
 
 func exportedStructFields(aStruct reflect.Value) map[string]reflect.Value {

--- a/faunadb/reflect.go
+++ b/faunadb/reflect.go
@@ -23,9 +23,16 @@ func exportedStructFields(aStruct reflect.Value) map[string]reflect.Value {
 			continue
 		}
 
-		fieldName := fieldName(aStructType.Field(i))
+		fieldName, ignore, omitempty, err := parseTag(aStructType.Field(i))
+		if err != nil {
+			//TODO Handle error in case of bad tag options? Currently invalid options are just skipped
+		}
 
-		if fieldName != "-" {
+		if omitempty && isEmptyValue(field) {
+			continue
+		}
+
+		if !ignore && fieldName != "" {
 			fields[fieldName] = field
 		}
 	}

--- a/faunadb/serialization_test.go
+++ b/faunadb/serialization_test.go
@@ -175,17 +175,21 @@ func TestSerializeStructWithTags(t *testing.T) {
 
 func TestSerializeStructWithOmitEmptyTags(t *testing.T) {
 	type user struct {
-		Name     string  `fauna:"name,omitempty"`
-		LastName string  `fauna:"last_name,omitempty"`
-		Age      int     `fauna:"age,omitempty"`
-		Siblings int     `fauna:"siblings,omitempty"`
-		Height   float64 `fauna:"height,omitempty"`
-		Weight   float64 `fauna:"weight,omitempty"`
+		Name          string   `fauna:"name,omitempty"`
+		LastName      string   `fauna:"last_name,omitempty"`
+		Age           int      `fauna:"age,omitempty"`
+		Siblings      int      `fauna:"siblings,omitempty"`
+		Height        float64  `fauna:"height,omitempty"`
+		Weight        float64  `fauna:"weight,omitempty"`
+		HeightPointer *float64 `fauna:"height_pointer,omitempty"`
+		WeightPointer *float64 `fauna:"weight_pointer,omitempty"`
 	}
 
+	f := func(f float64) *float64 { return &f }
+
 	assertJSON(t,
-		Obj{"data": user{"Jhon", "", 18, 0, 123.123, 0.0}},
-		`{"object":{"data":{"object":{"age":18, "height":123.123, "name":"Jhon"}}}}`,
+		Obj{"data": user{"Jhon", "", 18, 0, 123.123, 0.0, f(123.123), nil}},
+		`{"object":{"data":{"object":{"age":18, "height":123.123,"height_pointer":123.123, "name":"Jhon"}}}}`,
 	)
 }
 

--- a/faunadb/serialization_test.go
+++ b/faunadb/serialization_test.go
@@ -173,6 +173,22 @@ func TestSerializeStructWithTags(t *testing.T) {
 	)
 }
 
+func TestSerializeStructWithOmitEmptyTags(t *testing.T) {
+	type user struct {
+		Name     string  `fauna:"name,omitempty"`
+		LastName string  `fauna:"last_name,omitempty"`
+		Age      int     `fauna:"age,omitempty"`
+		Siblings int     `fauna:"siblings,omitempty"`
+		Height   float64 `fauna:"height,omitempty"`
+		Weight   float64 `fauna:"weight,omitempty"`
+	}
+
+	assertJSON(t,
+		Obj{"data": user{"Jhon", "", 18, 0, 123.123, 0.0}},
+		`{"object":{"data":{"object":{"age":18, "height":123.123, "name":"Jhon"}}}}`,
+	)
+}
+
 func TestSerializeStructWithIgnoredFields(t *testing.T) {
 	type user struct {
 		Name string `fauna:"name"`

--- a/faunadb/tags.go
+++ b/faunadb/tags.go
@@ -1,6 +1,11 @@
 package faunadb
 
-import "reflect"
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+)
 
 const faunaTag = "fauna"
 
@@ -12,4 +17,58 @@ func fieldName(field reflect.StructField) string {
 	}
 
 	return name
+}
+
+// parseTag interprets fauna struct field tags
+func parseTag(field reflect.StructField) (name string, ignore, omitempty bool, err error) {
+	s := field.Tag.Get(faunaTag)
+	parts := strings.Split(s, ",")
+	if s == "" {
+		return field.Name, false, false, nil
+	}
+
+	if parts[0] == "-" {
+		return "", true, false, nil
+	}
+
+	if len(parts) > 1 {
+		for _, p := range parts[1:] {
+			switch p {
+			case "omitempty":
+				omitempty = true
+			default:
+				err = fmt.Errorf("fauna: struct tag has invalid option: %q", p)
+				return "", false, false, err
+			}
+		}
+	}
+	if parts[0] != "" {
+		name = parts[0]
+	} else {
+		name = field.Name
+	}
+
+	return name, ignore, omitempty, nil
+}
+
+func isEmptyValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Ptr:
+		return v.IsNil()
+	case reflect.Struct:
+		if t, ok := v.Interface().(time.Time); ok {
+			return t.IsZero()
+		}
+	}
+	return false
 }

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,5 @@
 module github.com/fauna/faunadb-go/v3
 
-require (
-	github.com/fauna/faunadb-go v2.0.0+incompatible // indirect
-	github.com/stretchr/testify v1.6.1
-)
+require github.com/stretchr/testify v1.6.1
 
 go 1.14

--- a/go.sum
+++ b/go.sum
@@ -1,15 +1,9 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/fauna/faunadb-go v2.0.0+incompatible h1:b+iaebxQ37qQtQCEYpfatxeZVF+L0HTBTTrCMcV8itI=
-github.com/fauna/faunadb-go v2.0.0+incompatible/go.mod h1:WYAh1hNDFEgbsKKeUhsHPGIFkpQ1CGn/5XejAFfOhHg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
-github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=


### PR DESCRIPTION
This commit fixes #123 and enables discarding zero valued fields when saving structs that are tagged with **omitempty**

Test is included, existing functionality with tagging with a name and ignoring with `-` is maintained

```go
func TestSerializeStructWithOmitEmptyTags(t *testing.T) {
	type user struct {
		Name     string  `fauna:"name,omitempty"`
		LastName string  `fauna:"last_name,omitempty"`
		Age      int     `fauna:"age,omitempty"`
		Siblings int     `fauna:"siblings,omitempty"`
		Height   float64 `fauna:"height,omitempty"`
		Weight   float64 `fauna:"weight,omitempty"`
	}

	assertJSON(t,
		Obj{"data": user{"Jhon", "", 18, 0, 123.123, 0.0}},
		`{"object":{"data":{"object":{"age":18, "height":123.123, "name":"Jhon"}}}}`,
	)
}
```