### PR TITLE
DRV-489: Added runtime env/partner info to headers

### DIFF
--- a/faunadb/client.go
+++ b/faunadb/client.go
@@ -175,16 +175,16 @@ func NewFaunaClient(secret string, configs ...ClientConfig) *FaunaClient {
 }
 
 func getRuntimeEnvironmentOs() string {
-	os := runtime.GOOS
-	switch os {
+	envOS := runtime.GOOS
+	switch envOS {
 	case "windows":
-		return "Windows"
+		return "windows"
 	case "darwin":
-		return "MAC"
+		return "darwin"
 	case "linux":
-		return "Linux"
+		return "linux"
 	default:
-		return "Unknown"
+		return "unknown"
 	}
 }
 func getRuntimeEnvironment() string {

--- a/faunadb/client.go
+++ b/faunadb/client.go
@@ -177,12 +177,8 @@ func NewFaunaClient(secret string, configs ...ClientConfig) *FaunaClient {
 func getRuntimeEnvironmentOs() string {
 	envOS := runtime.GOOS
 	switch envOS {
-	case "windows":
-		return "windows"
-	case "darwin":
-		return "darwin"
-	case "linux":
-		return "linux"
+	case "windows", "darwin", "linux":
+		return envOS
 	default:
 		return "unknown"
 	}

--- a/faunadb/client.go
+++ b/faunadb/client.go
@@ -194,8 +194,7 @@ func getRuntimeEnvironment() string {
 		"AWS_LAMBDA_FUNCTION_VERSION":               "AWS Lambda",
 		"GOOGLE_CLOUD_PROJECT":                      "GCP Compute Instances",
 		"WEBSITE_FUNCTIONS_AZUREMONITOR_CATEGORIES": "Azure Cloud Functions",
-		"RENDER_SERVICE_ID":                         "Render",
-		"BEGIN_DATA_SCOPE_ID":                       "Begin",
+		"XDG_SESSION_ID":                            "AWS EC2",
 	}
 	for k := range env {
 		if _, ok := os.LookupEnv(k); ok {


### PR DESCRIPTION
This PR applied new set of headers based on environment/partner information.

- X-Runtime-Environment
name of runtime env (ex: Netlify, Vercel, etc..) or Unknown for an environment that can't be recognizable

- X-Runtime-Environment-OS
Name of OS (ex: darwin, linux)

For more detailes see - [DRV-489](https://faunadb.atlassian.net/browse/DRV-489).
