### PR TITLE
DRV-520: Fix Godoc Link to Use the Correct Module Path

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ For more information about FaunaDB query language, consult our query language
 [reference documentation](https://docs.fauna.com/fauna/current/reference/queryapi/).
 
 Specific reference documentation for the driver is hosted at
-[GoDoc](https://godoc.org/github.com/fauna/faunadb-go/faunadb).
+[GoDoc](https://pkg.go.dev/github.com/fauna/faunadb-go/v3).
 
 
 Most users found tests for the driver as a very useful form of documentation

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # FaunaDB Go Driver
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/fauna/faunadb-go)](https://goreportcard.com/report/github.com/fauna/faunadb-go)
-[![GoDoc](https://godoc.org/github.com/fauna/faunadb-go/faunadb?status.svg)](https://pkg.go.dev/github.com/fauna/faunadb-go?tab=overview)
+[![GoDoc](https://godoc.org/github.com/fauna/faunadb-go/faunadb?status.svg)](https://pkg.go.dev/github.com/fauna/faunadb-go/v3)
 [![License](https://img.shields.io/badge/license-MPL_2.0-blue.svg?maxAge=2592000)](https://raw.githubusercontent.com/fauna/faunadb-go/master/LICENSE)
 
 A Go lang driver for [FaunaDB](https://fauna.com/).


### PR DESCRIPTION
### Notes
I was trying to look at the driver's doc but found the same thing reported in issue #125 . It looks like that's because the module is defined as [github.com/fauna/faunadb-go/**v3**](https://github.com/fauna/faunadb-go/blob/master/go.mod#L1) so the [old link](https://pkg.go.dev/github.com/fauna/faunadb-go?tab=overview) doesn't resolve to the correct module documentation.  

I believe the correct link to the v3 (latest) release is https://pkg.go.dev/github.com/fauna/faunadb-go/v3.

### Jira ticket
https://faunadb.atlassian.net/browse/DRV-530