### PR TITLE
DRV-368: added support for omitempty field tag

### DIFF
--- a/faunadb/decode.go
+++ b/faunadb/decode.go
@@ -115,19 +115,31 @@ func (c *valueDecoder) makeNewMap(obj map[string]Value) error {
 	return c.assign(newMap)
 }
 
-func (c *valueDecoder) fillStructFields(obj map[string]Value) error {
+func (c *valueDecoder) fillStructFields(obj map[string]Value) (err error) {
 	newStruct := reflect.New(c.targetType).Elem()
+	aStructType := newStruct.Type()
 
-	for key, field := range exportedStructFields(newStruct) {
-		value, found := obj[key]
+	//need to get all StructFields and unpack json values into the fields to check if they are empty - use allStructFields rather than
+	for key, field := range allStructFields(newStruct) {
+		f, _ := aStructType.FieldByName(key)
+		if !field.CanInterface() {
+			continue
+		}
+		fieldName, ignored, _, _ := parseTag(f) //need to parse tags
+
+		value, found := obj[fieldName]
+
 		if !found {
 			continue
 		}
 
-		if err := value.Get(field); err != nil {
+		if ignored {
+			continue
+		}
+
+		if err = value.Get(field); err != nil {
 			return DecodeError{path: pathFromKeys(key), err: err}
 		}
 	}
-
 	return c.assign(newStruct)
 }

--- a/faunadb/deserialization_test.go
+++ b/faunadb/deserialization_test.go
@@ -504,8 +504,8 @@ func TestDeserializeStructWithOmitEmptyTags(t *testing.T) {
 
 	var obj object
 
-	require.NoError(t, decodeJSON(`{ "name": "Jhon", "age": 0 }`, &obj))
-	require.Equal(t, object{"Jhon", 0}, obj)
+	require.NoError(t, decodeJSON(`{ "name": "John", "age": 0 }`, &obj))
+	require.Equal(t, object{"John", 0}, obj)
 }
 
 func decodeJSON(raw string, target interface{}) (err error) {

--- a/faunadb/deserialization_test.go
+++ b/faunadb/deserialization_test.go
@@ -496,6 +496,18 @@ func TestDeserializeComplexStruct(t *testing.T) {
 	require.Equal(t, expected, object)
 }
 
+func TestDeserializeStructWithOmitEmptyTags(t *testing.T) {
+	type object struct {
+		Name string `fauna:"name,omitempty"`
+		Age  int64  `fauna:"age,omitempty"`
+	}
+
+	var obj object
+
+	require.NoError(t, decodeJSON(`{ "name": "Jhon", "age": 0 }`, &obj))
+	require.Equal(t, object{"Jhon", 0}, obj)
+}
+
 func decodeJSON(raw string, target interface{}) (err error) {
 	buffer := []byte(raw)
 

--- a/faunadb/reflect.go
+++ b/faunadb/reflect.go
@@ -23,9 +23,16 @@ func exportedStructFields(aStruct reflect.Value) map[string]reflect.Value {
 			continue
 		}
 
-		fieldName := fieldName(aStructType.Field(i))
+		fieldName, ignore, omitempty, err := parseTag(aStructType.Field(i))
+		if err != nil {
+			//TODO Handle error in case of bad tag options? Currently invalid options are just skipped
+		}
 
-		if fieldName != "-" {
+		if omitempty && isEmptyValue(field) {
+			continue
+		}
+
+		if !ignore && fieldName != "" {
 			fields[fieldName] = field
 		}
 	}
@@ -68,4 +75,26 @@ func indirectValue(i interface{}) (reflect.Value, reflect.Type) {
 	}
 
 	return value, value.Type()
+}
+
+func allStructFields(aStruct reflect.Value) map[string]reflect.Value {
+	fields := make(map[string]reflect.Value)
+	aStructType := aStruct.Type()
+
+	for i, size := 0, aStruct.NumField(); i < size; i++ {
+		field := aStruct.Field(i)
+		structTypeField := aStructType.Field(i)
+		if !field.CanInterface() {
+			continue
+		}
+
+		fieldName, ignore, _, _ := parseTag(aStructType.Field(i))
+
+		if !ignore && fieldName != "" {
+			fields[fieldName] = field
+		}
+		fields[structTypeField.Name] = field
+	}
+
+	return fields
 }

--- a/faunadb/serialization_test.go
+++ b/faunadb/serialization_test.go
@@ -1820,17 +1820,19 @@ func TestSerializeAccessProviders(t *testing.T) {
 	)
 }
 
-type OmitStruct struct {
-	Name           string   `fauna:"name,omitempty"`
-	Age            int      `fauna:"age,omitempty"`
-	Payment        float64  `fauna:"payment,omitempty"`
-	AgePointer     *int     `fauna:"agePointer,omitempty"`
-	PaymentPointer *float64 `fauna:"paymentPointer,omitempty"`
-}
-
 func TestSerializeStructWithOmitEmptyTags(t *testing.T) {
+	type TestStruct struct{}
+	type OmitStruct struct {
+		Name           string      `fauna:"name,omitempty"`
+		Age            int         `fauna:"age,omitempty"`
+		Payment        float64     `fauna:"payment,omitempty"`
+		AgePointer     *int        `fauna:"agePointer,omitempty"`
+		PaymentPointer *float64    `fauna:"paymentPointer,omitempty"`
+		Struct         *TestStruct `fauna:"struct,omitempty"`
+	}
 	x := 10
 	y := 42.42
+	z := TestStruct{}
 	tests := []struct {
 		name string
 		expr Expr
@@ -1876,7 +1878,16 @@ func TestSerializeStructWithOmitEmptyTags(t *testing.T) {
 			expr: Obj{"data": OmitStruct{Name: "", Age: 0, Payment: 0.0, AgePointer: nil, PaymentPointer: nil}},
 			want: `{"object":{"data":{"object":{}}}}`,
 		},
-
+		{
+			name: "Non-empty struct",
+			expr: Obj{"data": OmitStruct{Struct: &z}},
+			want: `{"object":{"data":{"object":{"struct":{"object":{}}}}}}`,
+		},
+		{
+			name: "Empty struct",
+			expr: Obj{"data": OmitStruct{Struct: nil}},
+			want: `{"object":{"data":{"object":{}}}}`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/faunadb/tags.go
+++ b/faunadb/tags.go
@@ -1,6 +1,11 @@
 package faunadb
 
-import "reflect"
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+)
 
 const faunaTag = "fauna"
 
@@ -12,4 +17,58 @@ func fieldName(field reflect.StructField) string {
 	}
 
 	return name
+}
+
+// parseTag interprets fauna struct field tags
+func parseTag(field reflect.StructField) (name string, ignore, omitempty bool, err error) {
+	s := field.Tag.Get(faunaTag)
+	parts := strings.Split(s, ",")
+	if s == "" {
+		return field.Name, false, false, nil
+	}
+
+	if parts[0] == "-" {
+		return "", true, false, nil
+	}
+
+	if len(parts) > 1 {
+		for _, p := range parts[1:] {
+			switch p {
+			case "omitempty":
+				omitempty = true
+			default:
+				err = fmt.Errorf("fauna: struct tag has invalid option: %q", p)
+				return "", false, false, err
+			}
+		}
+	}
+	if parts[0] != "" {
+		name = parts[0]
+	} else {
+		name = field.Name
+	}
+
+	return name, ignore, omitempty, nil
+}
+
+func isEmptyValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Ptr:
+		return v.IsNil()
+	case reflect.Struct:
+		if t, ok := v.Interface().(time.Time); ok {
+			return t.IsZero()
+		}
+	}
+	return false
 }

--- a/faunadb/tags.go
+++ b/faunadb/tags.go
@@ -48,7 +48,7 @@ func parseTag(field reflect.StructField) (name string, ignore, omitempty bool, e
 		name = field.Name
 	}
 
-	return name, ignore, omitempty, nil
+	return
 }
 
 func isEmptyValue(v reflect.Value) bool {


### PR DESCRIPTION
This commit fixes [#123](https://github.com/fauna/faunadb-go/issues/123) and enables discarding zero valued fields when saving structs that are tagged with omitempty.
```go
func TestSerializeStructWithOmitEmptyTags(t *testing.T) {
	type TestStruct struct{}
	type OmitStruct struct {
		Name           string      `fauna:"name,omitempty"`
		Age            int         `fauna:"age,omitempty"`
		Payment        float64     `fauna:"payment,omitempty"`
		AgePointer     *int        `fauna:"agePointer,omitempty"`
		PaymentPointer *float64    `fauna:"paymentPointer,omitempty"`
		Struct         *TestStruct `fauna:"struct,omitempty"`
	}
	x := 10
	y := 42.42
	z := TestStruct{}
	tests := []struct {
		name string
		expr Expr
		want string
	}{
		{
			name: "Empty Int",
			expr: Obj{"data": OmitStruct{Name: "John", Age: 0}},
			want: `{"object":{"data":{"object":{"name":"John"}}}}`,
		},
		{
			name: "Empty String",
			expr: Obj{"data": OmitStruct{Name: "", Age: 30}},
			want: `{"object":{"data":{"object":{"age":30}}}}`,
		},
		{
			name: "Empty Float",
			expr: Obj{"data": OmitStruct{Name: "John", Payment: 0.0}},
			want: `{"object":{"data":{"object":{"name":"John"}}}}`,
		},
		{
			name: "Int pointer",
			expr: Obj{"data": OmitStruct{Name: "", AgePointer: &x}},
			want: `{"object":{"data":{"object":{"agePointer":10}}}}`,
		},
		{
			name: "Empty Int pointer",
			expr: Obj{"data": OmitStruct{Name: "John", AgePointer: nil}},
			want: `{"object":{"data":{"object":{"name":"John"}}}}`,
		},
		{
			name: "Float pointer",
			expr: Obj{"data": OmitStruct{Name: "", PaymentPointer: &y}},
			want: `{"object":{"data":{"object":{"paymentPointer":42.42}}}}`,
		},
		{
			name: "Empty Float pointer",
			expr: Obj{"data": OmitStruct{Name: "John", PaymentPointer: nil}},
			want: `{"object":{"data":{"object":{"name":"John"}}}}`,
		},
		{
			name: "All data is empty",
			expr: Obj{"data": OmitStruct{Name: "", Age: 0, Payment: 0.0, AgePointer: nil, PaymentPointer: nil}},
			want: `{"object":{"data":{"object":{}}}}`,
		},
		{
			name: "Non-empty struct",
			expr: Obj{"data": OmitStruct{Struct: &z}},
			want: `{"object":{"data":{"object":{"struct":{"object":{}}}}}}`,
		},
		{
			name: "Empty struct",
			expr: Obj{"data": OmitStruct{Struct: nil}},
			want: `{"object":{"data":{"object":{}}}}`,
		},
	}
	for _, tt := range tests {
		t.Run(tt.name, func(t *testing.T) {
			got, err := json.Marshal(tt.expr)
			require.NoError(t, err)
			require.JSONEq(t, tt.want, string(got))
		})
	}
}
```