### PR TITLE
DRV-571: create way to identify fauna tooling in drivers

### DIFF
--- a/faunadb/client.go
+++ b/faunadb/client.go
@@ -40,6 +40,9 @@ func Endpoint(url string) ClientConfig { return func(cli *FaunaClient) { cli.end
 // HTTP allows the user to override the http.Client used by a FaunaClient.
 func HTTP(http *http.Client) ClientConfig { return func(cli *FaunaClient) { cli.http = http } }
 
+// Headers configures the http headers for a FaunaClient.
+func Headers(headers map[string]string) ClientConfig { return func(cli *FaunaClient) { cli.headers = headers } }
+
 /*
 EnableTxnTimePassthrough configures the FaunaClient to keep track of the last seen transaction time.
 The last seen transaction time is used to avoid reading stale data from outdated replicas when
@@ -165,7 +168,7 @@ func NewFaunaClient(secret string, configs ...ClientConfig) *FaunaClient {
 		client.observer = func(queryResult *QueryResult) {}
 	}
 
-	client.headers = map[string]string{
+	infoHeaders := map[string]string{
 		"Content-Type":             "application/json; charset=utf-8",
 		"X-FaunaDB-API-Version":    apiVersion,
 		"X-Fauna-Driver":           headerFaunaDriver,
@@ -173,6 +176,13 @@ func NewFaunaClient(secret string, configs ...ClientConfig) *FaunaClient {
 		"X-Runtime-Environment":    getRuntimeEnvironment(),
 		"X-GO-Version":             runtime.Version(),
 		"X-Query-Timeout":          strconv.FormatUint(client.queryTimeoutMs, 10),
+	}
+	if len(client.headers) == 0 {
+		client.headers = infoHeaders
+	} else {
+		for k, v := range infoHeaders {
+			client.headers[k] = v
+		}
 	}
 
 	if client.queryTimeoutMs > 0 {

--- a/faunadb/errors.go
+++ b/faunadb/errors.go
@@ -43,12 +43,12 @@ type QueryError struct {
 	Position    []string            `fauna:"position"`
 	Code        string              `fauna:"code"`
 	Description string              `fauna:"description"`
-	Failures    []ValidationFailure `fauna:"failures"`
+	Cause       []ValidationFailure `fauna:"cause"`
 }
 
 // ValidationFailure describes validation errors on a submitted query.
 type ValidationFailure struct {
-	Field       []string `fauna:"field"`
+	Position    []string `fauna:"position"`
 	Code        string   `fauna:"code"`
 	Description string   `fauna:"description"`
 }
@@ -71,13 +71,15 @@ func (err *errorResponse) queryErrors() string {
 		return "Unparseable server response."
 	}
 
-	errors := make([]string, len(err.errors))
+	errs := make([]string, len(err.errors))
 
 	for i, queryError := range err.errors {
-		errors[i] = fmt.Sprintf("[%s](%s): %s", strings.Join(queryError.Position, "/"), queryError.Code, queryError.Description)
+
+		errs[i] =
+			fmt.Sprintf("[%s](%s): %s, details: %s", strings.Join(queryError.Position, "/"), queryError.Code, queryError.Description, queryError.Cause)
 	}
 
-	return fmt.Sprintf("Errors: %s", strings.Join(errors, ", "))
+	return fmt.Sprintf("Errors: %s", strings.Join(errs, ", "))
 }
 
 func checkForResponseErrors(response *http.Response) error {

--- a/faunadb/errors_test.go
+++ b/faunadb/errors_test.go
@@ -57,9 +57,9 @@ func TestParseErrorResponse(t *testing.T) {
 				"position": [ "data", "token" ],
 				"code": "invalid token",
 				"description": "Invalid token.",
-				"failures": [
+				"cause": [
 					{
-						"field": [ "data", "token" ],
+						"position": [ "data", "token" ],
 						"code": "invalid token",
 						"description": "invalid token"
 					}
@@ -78,9 +78,9 @@ func TestParseErrorResponse(t *testing.T) {
 					Position:    []string{"data", "token"},
 					Code:        "invalid token",
 					Description: "Invalid token.",
-					Failures: []ValidationFailure{
+					Cause: []ValidationFailure{
 						{
-							Field:       []string{"data", "token"},
+							Position:    []string{"data", "token"},
 							Code:        "invalid token",
 							Description: "invalid token",
 						},
@@ -91,7 +91,7 @@ func TestParseErrorResponse(t *testing.T) {
 	}
 
 	require.Equal(t, expectedError, err)
-	require.EqualError(t, err, "Response error 401. Errors: [data/token](invalid token): Invalid token.")
+	require.EqualError(t, err, "Response error 401. Errors: [data/token](invalid token): Invalid token., details: [{[data token] invalid token invalid token}]")
 }
 
 func TestUnparseableResponse(t *testing.T) {
@@ -116,3 +116,4 @@ func errorResponseWith(status int, errors []QueryError) errorResponse {
 		errors:    errors,
 	}
 }
+

--- a/faunadb/stream_test.go
+++ b/faunadb/stream_test.go
@@ -66,7 +66,7 @@ func (s *StreamsTestSuite) TestRejectNonReadOnlyQuery() {
 	query := f.CreateCollection(f.Obj{"name": "collection"})
 	sub := s.client.Stream(query)
 	err := sub.Start()
-	s.EqualError(err, "Response error 400. Errors: [](invalid expression): Write effect in read-only query expression.")
+	s.EqualError(err, "Response error 400. Errors: [](invalid expression): Write effect in read-only query expression., details: []")
 }
 
 func (s *StreamsTestSuite) TestSelectFields() {
@@ -138,7 +138,7 @@ func (s *StreamsTestSuite) TestHandleBadQuery() {
 
 	sub := s.client.Stream(query)
 	err := sub.Start()
-	s.EqualError(err, "Response error 400. Errors: [](invalid argument): Expected a Document Ref or Version, got String.")
+	s.EqualError(err, "Response error 400. Errors: [](invalid argument): Expected a Document Ref or Version, got String., details: []")
 
 }
 


### PR DESCRIPTION
- User are able to provide custom headers via FaunaClient:
```go
dbClient = f.NewFaunaClient(sec, f.Headers(map[string]string{"X-Fauna-Source": "Console"}))
```