### PR TITLE
DRV-15: add support for paginate cursor object

### DIFF
--- a/faunadb/functions_read.go
+++ b/faunadb/functions_read.go
@@ -88,6 +88,7 @@ func Paginate(set interface{}, options ...OptionalParameter) Expr {
 type paginateFn struct {
 	fnApply
 	Paginate Expr `json:"paginate"`
+	Cursor   Expr `json:"cursor,omitempty" faunarepr:"optfn"`
 	After    Expr `json:"after,omitempty" faunarepr:"optfn"`
 	Before   Expr `json:"before,omitempty" faunarepr:"optfn"`
 	Events   Expr `json:"events,omitempty" faunarepr:"fn=optfn,name=EventsOpt"`

--- a/faunadb/query.go
+++ b/faunadb/query.go
@@ -128,6 +128,26 @@ func (fn getFn) setTS(e Expr) Expr {
 	return fn
 }
 
+func Cursor(ref interface{}) OptionalParameter {
+	return func(expr Expr) Expr {
+		switch e := expr.(type) {
+		case cursorParam:
+			return e.setCursor(wrap(ref))
+		default:
+			return e
+		}
+	}
+}
+
+type cursorParam interface {
+	setCursor(cursor Expr) Expr
+}
+
+func (fn paginateFn) setCursor(e Expr) Expr {
+	fn.Cursor = e
+	return fn
+}
+
 // After is an optional parameter used when cursoring that refers to the specified cursor's the next page, inclusive.
 // For more information about pages, check https://app.fauna.com/documentation/reference/queryapi#simple-type-pages.
 //

--- a/faunadb/serialization_test.go
+++ b/faunadb/serialization_test.go
@@ -585,13 +585,14 @@ func TestSerializePaginateWithParameters(t *testing.T) {
 			Ref("databases"),
 			Before(Ref("databases/test10")),
 			After(Ref("databases/test")),
+			Cursor(Obj{"before": Ref("databases/test")}),
 			EventsOpt(true),
 			Sources(true),
 			TS(10),
 			Size(2),
 		),
 		`{"after":{"@ref":"databases/test"},"before":{"@ref":"databases/test10"},"events":true,`+
-			`"paginate":{"@ref":"databases"},"size":2,"sources":true,"ts":10}`,
+			`"paginate":{"@ref":"databases"},"size":2,"sources":true,"ts":10,"cursor":{"object":{"before":{"@ref":"databases/test"}}}}`,
 	)
 }
 


### PR DESCRIPTION
Introduce `cursor` parameter to provide `before/after` cursors.
E.g.:
```go
res = s.query(
		f.Paginate(
			f.Documents(f.Collection(collectionName)),
			f.Size(3),
			f.Cursor(nil),
		))
```
```go
res = s.query(
		f.Paginate(
			f.Documents(f.Collection(paginateColName)),
			f.Cursor(f.Obj{"before": f.Ref(...)}),
		))
```