### PR TITLE
Test fix: Use "core" Fauna Dev Docker image instead of "enterprise" (v5)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ executors:
     docker:
       - image: circleci/golang:<<parameters.go_version>>
 
-      - image: gcr.io/faunadb-cloud/faunadb/enterprise:latest
+      - image: gcr.io/faunadb-cloud/faunadb/core/nightly:latest
         name: core
         auth:
           username: _json_key

--- a/concourse/tasks/integration.yml
+++ b/concourse/tasks/integration.yml
@@ -2,7 +2,7 @@ version: "3.3"
 
 services:
   faunadb:
-    image: gcr.io/faunadb-cloud/faunadb/enterprise:latest
+    image: gcr.io/faunadb-cloud/faunadb/core/nightly:latest
     container_name: faunadb
     healthcheck:
       test: ["CMD", "curl" ,"http://faunadb:8443/ping"]


### PR DESCRIPTION
The Go driver currently uses the out-of-date "enterprise" flavor of the Fauna Dev Docker image; this change migrates to using the "core" flavor instead.

The CircleCI workflow will test this change with existing test automation.