### PR TITLE
Adding tag and traceparent functionality with simple tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,11 @@ commands:
           key: v1-deps-{{ checksum "go.sum" }}
 
       - run:
+          name: Wait FaunaDB init
+          command: |
+            while ! $(curl --output /dev/null --silent --fail --max-time 1 http://core:8443/ping); do sleep 1; done
+
+      - run:
           name: Run Tests
           command: |
             mkdir results

--- a/faunadb/client.go
+++ b/faunadb/client.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -24,9 +25,14 @@ const (
 	apiVersion        = "4"
 	defaultEndpoint   = "https://db.fauna.com"
 	requestTimeout    = 60 * time.Second
+	headerFaunaDriver = "go"
 	headerTxnTime     = "X-Txn-Time"
 	headerLastSeenTxn = "X-Last-Seen-Txn"
-	headerFaunaDriver = "go"
+	headerTraceparent = "Traceparent"
+	headerTags        = "X-Fauna-Tags"
+	maxTagEntries     = 25
+	maxTagKeyLength   = 40
+	maxTagValueLength = 80
 )
 
 var resource = ObjKey("resource")
@@ -41,7 +47,9 @@ func Endpoint(url string) ClientConfig { return func(cli *FaunaClient) { cli.end
 func HTTP(http *http.Client) ClientConfig { return func(cli *FaunaClient) { cli.http = http } }
 
 // Headers configures the http headers for a FaunaClient.
-func Headers(headers map[string]string) ClientConfig { return func(cli *FaunaClient) { cli.headers = headers } }
+func Headers(headers map[string]string) ClientConfig {
+	return func(cli *FaunaClient) { cli.headers = headers }
+}
 
 /*
 EnableTxnTimePassthrough configures the FaunaClient to keep track of the last seen transaction time.
@@ -72,8 +80,38 @@ func DisableTxnTimePassthrough() ClientConfig {
 	return func(cli *FaunaClient) { cli.isTxnTimeEnabled = false }
 }
 
-//QueryConfig is the base type for query specific configuration parameters.
+// QueryConfig is the base type for query specific configuration parameters.
 type QueryConfig func(*faunaRequest)
+
+func Traceparent(tp string) QueryConfig {
+	return func(req *faunaRequest) {
+		// drop the traceparent if it isn't in the expected format
+		r, _ := regexp.Compile("^[\\da-f]{2}-[\\da-f]{32}-[\\da-f]{16}-[\\da-f]{2}$")
+		if r.MatchString(tp) {
+			req.headers[headerTraceparent] = tp
+		}
+	}
+}
+
+func Tag(key string, value string) QueryConfig {
+	return func(req *faunaRequest) {
+
+		// drop the tag if the key or value are too long
+		if len(key) <= maxTagKeyLength && len(value) <= maxTagValueLength {
+			h := req.headers[headerTags]
+			tags := strings.Split(h, ",")
+
+			// drop the tag if over the entry limit
+			if len(tags) <= maxTagEntries {
+				if h != "" {
+					h = h + ","
+				}
+				h = h + key + "=" + value
+				req.headers[headerTags] = h
+			}
+		}
+	}
+}
 
 type faunaRequest struct {
 	headers map[string]string
@@ -126,6 +164,7 @@ type QueryResult struct {
 
 /*
 NewFaunaClient creates a new FaunaClient structure. Possible configuration options:
+
 	Endpoint: sets a specific FaunaDB url. Default: https://db.fauna.com
 	HTTP: sets a specific http.Client. Default: a new net.Client with 60 seconds timeout.
 */
@@ -413,8 +452,9 @@ func (client *FaunaClient) GetLastTxnTime() int64 {
 // SyncLastTxnTime syncs the freshest timestamp seen by this client.
 // This has no effect if more stale than the currently stored timestamp.
 // WARNING: This should be used only when coordinating timestamps across
-//          multiple clients. Moving the timestamp arbitrarily forward into
-//          the future will cause transactions to stall.
+//
+//	multiple clients. Moving the timestamp arbitrarily forward into
+//	the future will cause transactions to stall.
 func (client *FaunaClient) SyncLastTxnTime(newTxnTime int64) {
 	if client.isTxnTimeEnabled {
 		for {
@@ -479,6 +519,10 @@ func (client *FaunaClient) prepareRequest(ctx context.Context, body io.Reader, e
 			for k, v := range req.headers {
 				request.Header.Add(k, v)
 			}
+		}
+
+		if !isValidTraceparentHeader(request.Header) {
+			request.Header.Del(headerTraceparent)
 		}
 
 		client.addLastTxnTimeHeader(request)
@@ -564,6 +608,15 @@ func parseTxnTimeHeader(header http.Header) (txnTime int64, err error) {
 		txnTime, err = strconv.ParseInt(lastSeenHeader, 10, 64)
 	}
 	return
+}
+
+func isValidTraceparentHeader(header http.Header) bool {
+	tp := header.Get(headerTraceparent)
+	if tp == "" {
+		return true
+	}
+	r, _ := regexp.Compile("^[\\da-f]{2}-[\\da-f]{32}-[\\da-f]{16}-[\\da-f]{2}$")
+	return r.MatchString(tp)
 }
 
 func basicAuth(secret string) string {

--- a/faunadb/client.go
+++ b/faunadb/client.go
@@ -95,21 +95,12 @@ func Traceparent(tp string) QueryConfig {
 
 func Tag(key string, value string) QueryConfig {
 	return func(req *faunaRequest) {
-
-		// drop the tag if the key or value are too long
-		if len(key) <= maxTagKeyLength && len(value) <= maxTagValueLength {
-			h := req.headers[headerTags]
-			tags := strings.Split(h, ",")
-
-			// drop the tag if over the entry limit
-			if len(tags) <= maxTagEntries {
-				if h != "" {
-					h = h + ","
-				}
-				h = h + key + "=" + value
-				req.headers[headerTags] = h
-			}
+		h := req.headers[headerTags]
+		if h != "" {
+			h = h + ","
 		}
+		h = h + key + "=" + value
+		req.headers[headerTags] = h
 	}
 }
 

--- a/faunadb/client.go
+++ b/faunadb/client.go
@@ -30,9 +30,6 @@ const (
 	headerLastSeenTxn = "X-Last-Seen-Txn"
 	headerTraceparent = "Traceparent"
 	headerTags        = "X-Fauna-Tags"
-	maxTagEntries     = 25
-	maxTagKeyLength   = 40
-	maxTagValueLength = 80
 )
 
 var resource = ObjKey("resource")

--- a/faunadb/client.go
+++ b/faunadb/client.go
@@ -521,10 +521,6 @@ func (client *FaunaClient) prepareRequest(ctx context.Context, body io.Reader, e
 			}
 		}
 
-		if !isValidTraceparentHeader(request.Header) {
-			request.Header.Del(headerTraceparent)
-		}
-
 		client.addLastTxnTimeHeader(request)
 	}
 
@@ -608,15 +604,6 @@ func parseTxnTimeHeader(header http.Header) (txnTime int64, err error) {
 		txnTime, err = strconv.ParseInt(lastSeenHeader, 10, 64)
 	}
 	return
-}
-
-func isValidTraceparentHeader(header http.Header) bool {
-	tp := header.Get(headerTraceparent)
-	if tp == "" {
-		return true
-	}
-	r, _ := regexp.Compile("^[\\da-f]{2}-[\\da-f]{32}-[\\da-f]{16}-[\\da-f]{2}$")
-	return r.MatchString(tp)
 }
 
 func basicAuth(secret string) string {

--- a/faunadb/client_test.go
+++ b/faunadb/client_test.go
@@ -1,6 +1,8 @@
 package faunadb_test
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -26,19 +28,19 @@ var (
 )
 
 var randomCollection,
-paginateCollection,
-spells,
-spellbook,
-characters,
-allSpells,
-spellsByElement,
-elementsOfSpells,
-spellbookByOwner,
-spellBySpellbook,
-magicMissile,
-fireball,
-faerieFire,
-thor f.RefV
+	paginateCollection,
+	spells,
+	spellbook,
+	characters,
+	allSpells,
+	spellsByElement,
+	elementsOfSpells,
+	spellbookByOwner,
+	spellBySpellbook,
+	magicMissile,
+	fireball,
+	faerieFire,
+	thor f.RefV
 
 type Spellbook struct {
 	Owner f.RefV `fauna:"owner"`
@@ -2643,6 +2645,41 @@ func (s *ClientTestSuite) TestMetricsWithQueryResult() {
 	_, headers, err := s.client.QueryResult(f.NewId())
 	s.Require().NoError(err)
 	s.assertMetrics(headers)
+}
+
+func (s *ClientTestSuite) TestTraceparent() {
+	h := "Traceparent"
+	tp1 := "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+	seg1 := strings.Split(tp1, "-")
+	newClient := s.client.NewWithObserver(func(queryResult *f.QueryResult) {
+		s.Require().Contains(queryResult.Headers, h)
+		s.Require().Equal(1, len(queryResult.Headers[h]))
+		tp2 := queryResult.Headers[h][0]
+		seg2 := strings.Split(tp2, "-")
+		s.Require().Equal(len(seg1), len(seg2))
+		s.Require().Equal(seg1[0], seg2[0])
+		s.Require().Equal(seg1[1], seg2[1])
+	})
+	_, err := newClient.Query(f.NewId(), f.Traceparent(tp1))
+	s.Require().NoError(err)
+}
+
+func (s *ClientTestSuite) TestTags() {
+	fmt.Println("running")
+	h := "X-Fauna-Tags"
+	k := "foo"
+	v := "bar"
+	newClient := s.client.NewWithObserver(func(queryResult *f.QueryResult) {
+		s.Require().Contains(queryResult.Headers, h)
+		s.Require().Equal(1, len(queryResult.Headers[h]))
+		txt := queryResult.Headers[h][0]
+		tag := strings.Split(txt, "=")
+		s.Require().Equal(2, len(tag))
+		s.Require().Equal(k, tag[0])
+		s.Require().Equal(v, tag[1])
+	})
+	_, err := newClient.Query(f.NewId(), f.Tag(k, v))
+	s.Require().NoError(err)
 }
 
 func (s *ClientTestSuite) TestMetricsWithBatchQueryResult() {

--- a/faunadb/client_test.go
+++ b/faunadb/client_test.go
@@ -1,7 +1,6 @@
 package faunadb_test
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -2665,7 +2664,6 @@ func (s *ClientTestSuite) TestTraceparent() {
 }
 
 func (s *ClientTestSuite) TestTags() {
-	fmt.Println("running")
 	h := "X-Fauna-Tags"
 	k := "foo"
 	v := "bar"

--- a/faunadb/stream_test.go
+++ b/faunadb/stream_test.go
@@ -138,7 +138,7 @@ func (s *StreamsTestSuite) TestHandleBadQuery() {
 
 	sub := s.client.Stream(query)
 	err := sub.Start()
-	s.EqualError(err, "Response error 400. Errors: [](invalid argument): Expected a Document Ref or Version, got String., details: []")
+	s.EqualError(err, "Response error 400. Errors: [](invalid argument): Expected a Document Ref or Version, or a Set Ref, got String., details: []")
 
 }
 


### PR DESCRIPTION
This change creates new QueryConfigs that can be used to set the Traceparent header and X-Fauna-Tags header. Simple tests exercise the new headers and assert that they are returned in the response.